### PR TITLE
feat: add --format json to individual check commands (#54)

### DIFF
--- a/src/zenzic/cli.py
+++ b/src/zenzic/cli.py
@@ -111,6 +111,31 @@ def _apply_engine_override(config: ZenzicConfig, engine: str | None) -> ZenzicCo
     return config.model_copy(update={"build_context": new_context})
 
 
+def _output_json_findings(findings: list[Finding], elapsed: float) -> None:
+    """Serialize findings list to JSON and print to stdout."""
+    report = {
+        "findings": [
+            {
+                "rel_path": f.rel_path,
+                "line_no": f.line_no,
+                "code": f.code,
+                "severity": f.severity,
+                "message": f.message,
+            }
+            for f in findings
+        ],
+        "summary": {
+            "errors": sum(1 for f in findings if f.severity == "error"),
+            "warnings": sum(1 for f in findings if f.severity == "warning"),
+            "info": sum(1 for f in findings if f.severity == "info"),
+            "security_incidents": sum(1 for f in findings if f.severity == "security_incident"),
+            "security_breaches": sum(1 for f in findings if f.severity == "security_breach"),
+            "elapsed_seconds": round(elapsed, 3),
+        },
+    }
+    print(json.dumps(report, indent=2))
+
+
 def _render_link_error(err: LinkError, docs_root: Path) -> None:
     """Print a single LinkError with a Visual Snippet when source context is available."""
     try:
@@ -232,6 +257,7 @@ def _count_docs_assets(
 @check_app.command(name="links")
 def check_links(
     strict: bool = typer.Option(False, "--strict", "-s", help="Exit non-zero on any warning."),
+    output_format: str = typer.Option("text", "--format", help="Output format: text or json."),
     show_info: bool = typer.Option(
         False, "--show-info", help="Show info-level findings (e.g. circular links) in the report."
     ),
@@ -280,6 +306,16 @@ def check_links(
         for err in link_errors
     ]
 
+    if output_format == "json":
+        _output_json_findings(findings, elapsed)
+        incidents = sum(1 for f in findings if f.severity == "security_incident")
+        if incidents:
+            raise typer.Exit(3)
+        errors_count = sum(1 for f in findings if f.severity == "error")
+        if errors_count:
+            raise typer.Exit(1)
+        return
+
     docs_count, assets_count = _count_docs_assets(docs_root, repo_root, exclusion_mgr)
     reporter = SentinelReporter(console, docs_root, docs_dir=str(config.docs_dir))
     errors, warnings = reporter.render(
@@ -308,6 +344,7 @@ def check_orphans(
         "Auto-detected from zenzic.toml when omitted.",
         metavar="ENGINE",
     ),
+    output_format: str = typer.Option("text", "--format", help="Output format: text or json."),
     show_info: bool = typer.Option(
         False, "--show-info", help="Show info-level findings (e.g. circular links) in the report."
     ),
@@ -338,6 +375,12 @@ def check_orphans(
         for path in orphans
     ]
 
+    if output_format == "json":
+        _output_json_findings(findings, elapsed)
+        if findings:
+            raise typer.Exit(1)
+        return
+
     docs_count, assets_count = _count_docs_assets(docs_root, repo_root, exclusion_mgr)
     reporter = SentinelReporter(console, docs_root, docs_dir=str(config.docs_dir))
     errors, warnings = reporter.render(
@@ -357,6 +400,7 @@ def check_orphans(
 
 @check_app.command(name="snippets")
 def check_snippets(
+    output_format: str = typer.Option("text", "--format", help="Output format: text or json."),
     show_info: bool = typer.Option(
         False, "--show-info", help="Show info-level findings (e.g. circular links) in the report."
     ),
@@ -402,6 +446,13 @@ def check_snippets(
             )
         )
 
+    if output_format == "json":
+        _output_json_findings(findings, elapsed)
+        errors_count = sum(1 for f in findings if f.severity == "error")
+        if errors_count:
+            raise typer.Exit(1)
+        return
+
     docs_count, assets_count = _count_docs_assets(docs_root, repo_root, exclusion_mgr)
     reporter = SentinelReporter(console, docs_root, docs_dir=str(config.docs_dir))
     errors, warnings = reporter.render(
@@ -432,6 +483,7 @@ def check_references(
         "-l",
         help="Also validate external HTTP/HTTPS reference URLs via async HEAD requests.",
     ),
+    output_format: str = typer.Option("text", "--format", help="Output format: text or json."),
     show_info: bool = typer.Option(
         False, "--show-info", help="Show info-level findings (e.g. circular links) in the report."
     ),
@@ -525,6 +577,17 @@ def check_references(
             )
         )
 
+    if output_format == "json":
+        _output_json_findings(findings, elapsed)
+        breaches = sum(1 for f in findings if f.severity == "security_breach")
+        if breaches:
+            raise typer.Exit(2)
+        errors_count = sum(1 for f in findings if f.severity == "error")
+        warnings_count = sum(1 for f in findings if f.severity == "warning")
+        if errors_count or (strict and warnings_count):
+            raise typer.Exit(1)
+        return
+
     docs_count, assets_count = _count_docs_assets(docs_root, repo_root, exclusion_mgr)
     reporter = SentinelReporter(console, docs_root, docs_dir=str(config.docs_dir))
     errors, warnings = reporter.render(
@@ -548,6 +611,7 @@ def check_references(
 
 @check_app.command(name="assets")
 def check_assets(
+    output_format: str = typer.Option("text", "--format", help="Output format: text or json."),
     show_info: bool = typer.Option(
         False, "--show-info", help="Show info-level findings (e.g. circular links) in the report."
     ),
@@ -576,6 +640,12 @@ def check_assets(
         )
         for path in unused
     ]
+
+    if output_format == "json":
+        _output_json_findings(findings, elapsed)
+        if findings:
+            raise typer.Exit(1)
+        return
 
     docs_count, assets_count = _count_docs_assets(docs_root, repo_root, exclusion_mgr)
     reporter = SentinelReporter(console, docs_root, docs_dir=str(config.docs_dir))

--- a/tests/test_cli_e2e.py
+++ b/tests/test_cli_e2e.py
@@ -235,3 +235,98 @@ class TestExitCodePriorityE2E:
             f"Exit 3 (security_incident) must beat Exit 2 (security_breach), "
             f"got {result.exit_code}.\nOutput:\n{result.stdout}"
         )
+
+
+# ── --format json on individual check commands ──────────────────────────────
+
+
+class TestJsonFormatE2E:
+    """--format json outputs structured JSON on individual check commands."""
+
+    def test_check_links_json(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """check links --format json outputs valid JSON with findings/summary keys."""
+        _make_sandbox(tmp_path, {"docs/index.md": "# Hello\n\nEnough words to not be a placeholder for the scanner."})
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["check", "links", "--format", "json"])
+
+        assert result.exit_code == 0
+        import json
+
+        data = json.loads(result.stdout)
+        assert "findings" in data
+        assert "summary" in data
+        assert "errors" in data["summary"]
+        assert "elapsed_seconds" in data["summary"]
+
+    def test_check_orphans_json(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """check orphans --format json outputs valid JSON."""
+        _make_sandbox(tmp_path, {"docs/index.md": "# Home\n\nWords words words words words words words."})
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["check", "orphans", "--format", "json"])
+
+        assert result.exit_code == 0
+        import json
+
+        data = json.loads(result.stdout)
+        assert "findings" in data
+        assert "summary" in data
+
+    def test_check_snippets_json(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """check snippets --format json outputs valid JSON."""
+        _make_sandbox(tmp_path, {"docs/index.md": "# Home\n\nWords words words."})
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["check", "snippets", "--format", "json"])
+
+        assert result.exit_code == 0
+        import json
+
+        data = json.loads(result.stdout)
+        assert "findings" in data
+        assert "summary" in data
+
+    def test_check_references_json(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """check references --format json outputs valid JSON."""
+        _make_sandbox(tmp_path, {"docs/index.md": "# Home\n\nWords words words."})
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["check", "references", "--format", "json"])
+
+        assert result.exit_code == 0
+        import json
+
+        data = json.loads(result.stdout)
+        assert "findings" in data
+        assert "summary" in data
+
+    def test_check_assets_json(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """check assets --format json outputs valid JSON."""
+        _make_sandbox(tmp_path, {"docs/index.md": "# Home\n\nWords words words."})
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["check", "assets", "--format", "json"])
+
+        assert result.exit_code == 0
+        import json
+
+        data = json.loads(result.stdout)
+        assert "findings" in data
+        assert "summary" in data
+
+    def test_check_links_json_exit_code_on_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """check links --format json still exits 1 on broken links."""
+        _make_sandbox(tmp_path, {"docs/index.md": "# Home\n\n[Broken](nope.md)"})
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["check", "links", "--format", "json"])
+
+        assert result.exit_code == 1
+        import json
+
+        data = json.loads(result.stdout)
+        assert data["summary"]["errors"] > 0
+        assert len(data["findings"]) > 0


### PR DESCRIPTION
## Summary

Adds `--format json` flag to individual check commands (`links`, `orphans`, `snippets`, `references`, `assets`). Previously only `check all`, `score`, and `diff` supported JSON output.

Closes #54

## Changes

- **New helper**: `_output_json_findings()` — consistent JSON serialization for any findings list
- **5 commands updated**: `check links`, `check orphans`, `check snippets`, `check references`, `check assets` all accept `--format json`
- **Exit codes preserved**: JSON mode maintains the same exit-code contract (exit 1 on errors, exit 2 on security breaches, exit 3 on path traversal)
- **6 new E2E tests**: Cover JSON output structure and exit code behavior

## JSON Output Format

```json
{
  "findings": [{"rel_path": "...", "line_no": 0, "code": "...", "severity": "...", "message": "..."}],
  "summary": {"errors": 0, "warnings": 0, "info": 0, "security_incidents": 0, "security_breaches": 0, "elapsed_seconds": 0.042}
}
```

## Testing
All existing tests pass + 6 new E2E tests.