### PR TITLE
feat(shield): add GitLab Personal Access Token detection

### DIFF
--- a/src/zenzic/core/shield.py
+++ b/src/zenzic/core/shield.py
@@ -16,6 +16,7 @@ Supported patterns
 - Slack token:          ``xox[baprs]-[0-9a-zA-Z]{10,48}``
 - Google API key:       ``AIza[0-9A-Za-z\\-_]{35}``
 - Generic private key:  ``-----BEGIN [A-Z ]+ PRIVATE KEY-----``
+- GitLab PAT:           ``glpat-[A-Za-z0-9\-_]{20,}``
 
 Exit code contract
 ------------------
@@ -80,6 +81,7 @@ _SECRETS: list[tuple[str, re.Pattern[str]]] = [
     ("google-api-key", re.compile(r"AIza[0-9A-Za-z\-_]{35}")),
     ("private-key", re.compile(r"-----BEGIN [A-Z ]+ PRIVATE KEY-----")),
     ("hex-encoded-payload", re.compile(r"(?:\\x[0-9a-fA-F]{2}){3,}")),
+    ("gitlab-pat", re.compile(r"glpat-[A-Za-z0-9\-_]{20,}")),
 ]
 
 #: Maximum line length the Shield will scan.  Lines exceeding this limit

--- a/tests/test_redteam_remediation.py
+++ b/tests/test_redteam_remediation.py
@@ -273,6 +273,33 @@ class TestShieldNormalizer:
         types = [f.secret_type for f in findings]
         assert types.count("aws-access-key") == 1, "Deduplication must prevent double-emit"
 
+    def test_scan_line_catches_gitlab_pat(self) -> None:
+        """scan_line_for_secrets must catch a GitLab Personal Access Token."""
+        line = "token: glpat-xxxxxxxxxxxxxxxxxxxx"
+        findings = list(scan_line_for_secrets(line, Path("docs/config.md"), 1))
+        assert len(findings) >= 1
+        assert findings[0].secret_type == "gitlab-pat"
+
+    def test_scan_line_catches_gitlab_pat_in_url(self) -> None:
+        """GitLab PAT embedded in a URL must be detected."""
+        url = "https://gitlab.com/api/v4/projects?private_token=glpat-AbCdEfGhIjKlMnOpQrSt1234"
+        findings = list(scan_line_for_secrets(url, Path("docs/api.md"), 5))
+        secret_types = {f.secret_type for f in findings}
+        assert "gitlab-pat" in secret_types
+
+    def test_scan_line_no_false_positive_on_glpat_prefix(self) -> None:
+        """Short strings starting with glpat- must not trigger (need 20+ chars after)."""
+        line = "variable: glpat-short"
+        findings = list(scan_line_for_secrets(line, Path("docs/config.md"), 1))
+        gitlab_findings = [f for f in findings if f.secret_type == "gitlab-pat"]
+        assert gitlab_findings == []
+
+    def test_scan_line_no_false_positive_on_clean_line(self) -> None:
+        """Clean lines must not trigger GitLab PAT detection."""
+        line = "GitLab is a DevOps platform"
+        findings = list(scan_line_for_secrets(line, Path("docs/intro.md"), 1))
+        assert findings == []
+
 
 # ─── ZRT-004: VSMBrokenLinkRule context-aware URL resolution ──────────────────
 


### PR DESCRIPTION
## Summary

Adds GitLab Personal Access Token (`glpat-`) detection to the Shield credential scanner.

## Changes
- Added `gitlab-pat` pattern: `glpat-[A-Za-z0-9\-_]{20,}` to `_SECRETS` list
- Updated module docstring to document the new pattern
- Added 4 test cases:
  - Basic PAT detection
  - PAT embedded in URL
  - False positive guard (short strings)
  - Clean line verification

## Pattern Details
- Format: `glpat-` followed by 20+ alphanumeric/underscore/hyphen characters
- Minimum length ensures low false positive rate

## Testing
All regex patterns verified manually (project requires Python 3.10+ for full test suite).

Closes #53