### PR TITLE
fix: escape docstring + update [Unreleased] changelog (PR #55, #57)

### DIFF
--- a/CHANGELOG.it.md
+++ b/CHANGELOG.it.md
@@ -18,6 +18,9 @@ Le versioni seguono il [Semantic Versioning](https://semver.org/).
   con uno schema uniforme `findings`/`summary`. I codici di uscita sono preservati in
   modalità JSON.
   ([#55](https://github.com/PythonWoods/zenzic/pull/55) — contributo di [@xyaz1313](https://github.com/xyaz1313))
+- **Shield: rilevamento GitLab Personal Access Token.** Lo scanner di credenziali
+  rileva ora i token `glpat-` (9 famiglie di credenziali in totale).
+  ([#57](https://github.com/PythonWoods/zenzic/pull/57) — contributo di [@gtanb4l](https://github.com/gtanb4l))
 
 ## [0.6.1rc1] — 2026-04-15 — Obsidian Bastion
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
   `check snippets`, `check references`, and `check assets` now accept `--format json`
   with a uniform `findings`/`summary` schema. Exit codes are preserved in JSON mode.
   ([#55](https://github.com/PythonWoods/zenzic/pull/55) — contributed by [@xyaz1313](https://github.com/xyaz1313))
+- **Shield: GitLab Personal Access Token detection.** The credential scanner now
+  detects `glpat-` tokens (9 credential families total).
+  ([#57](https://github.com/PythonWoods/zenzic/pull/57) — contributed by [@gtanb4l](https://github.com/gtanb4l))
 
 ## [0.6.1rc1] — 2026-04-15 — Obsidian Bastion
 

--- a/src/zenzic/core/shield.py
+++ b/src/zenzic/core/shield.py
@@ -16,7 +16,7 @@ Supported patterns
 - Slack token:          ``xox[baprs]-[0-9a-zA-Z]{10,48}``
 - Google API key:       ``AIza[0-9A-Za-z\\-_]{35}``
 - Generic private key:  ``-----BEGIN [A-Z ]+ PRIVATE KEY-----``
-- GitLab PAT:           ``glpat-[A-Za-z0-9\-_]{20,}``
+- GitLab PAT:           ``glpat-[A-Za-z0-9\\-_]{20,}``
 
 Exit code contract
 ------------------


### PR DESCRIPTION
- Fix SyntaxWarning in Shield docstring (\- → \\-), follow-up to PR #57
- Add PR #55 (--format json individual commands) to [Unreleased] (EN+IT)
- Add PR #57 (GitLab PAT detection) to [Unreleased] (EN+IT)