### PR TITLE
fix: JSON exit-code asymmetry in check_orphans and check_assets

### DIFF
--- a/CHANGELOG.it.md
+++ b/CHANGELOG.it.md
@@ -22,6 +22,13 @@ Le versioni seguono il [Semantic Versioning](https://semver.org/).
   rileva ora i token `glpat-` (9 famiglie di credenziali in totale).
   ([#57](https://github.com/PythonWoods/zenzic/pull/57) — contributo di [@gtanb4l](https://github.com/gtanb4l))
 
+### Corretto
+
+- **Asimmetria exit-code JSON in `check orphans` e `check assets`.** Entrambi i comandi
+  ora distinguono la severità `error` da `warning` prima di decidere il codice di uscita,
+  in modo coerente con `check references` e `check snippets`. In precedenza, qualsiasi
+  finding (inclusi i warning) attivava Exit 1 in modalità JSON.
+
 ## [0.6.1rc1] — 2026-04-15 — Obsidian Bastion
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ Versions follow [Semantic Versioning](https://semver.org/).
   detects `glpat-` tokens (9 credential families total).
   ([#57](https://github.com/PythonWoods/zenzic/pull/57) — contributed by [@gtanb4l](https://github.com/gtanb4l))
 
+### Fixed
+
+- **JSON exit-code asymmetry in `check orphans` and `check assets`.** Both commands
+  now distinguish `error` vs `warning` severity before deciding exit codes, consistent
+  with `check references` and `check snippets`. Previously, any finding (including
+  warnings) triggered Exit 1 in JSON mode.
+
 ## [0.6.1rc1] — 2026-04-15 — Obsidian Bastion
 
 ### Breaking Changes

--- a/src/zenzic/cli.py
+++ b/src/zenzic/cli.py
@@ -377,7 +377,8 @@ def check_orphans(
 
     if output_format == "json":
         _output_json_findings(findings, elapsed)
-        if findings:
+        errors_count = sum(1 for f in findings if f.severity == "error")
+        if errors_count:
             raise typer.Exit(1)
         return
 
@@ -643,7 +644,8 @@ def check_assets(
 
     if output_format == "json":
         _output_json_findings(findings, elapsed)
-        if findings:
+        errors_count = sum(1 for f in findings if f.severity == "error")
+        if errors_count:
             raise typer.Exit(1)
         return
 


### PR DESCRIPTION
## Summary

- `check_orphans` and `check_assets` in JSON mode now distinguish `error` vs `warning` severity before deciding exit codes
- Previously, any finding (including warnings) triggered Exit 1 — inconsistent with `check_references` and `check_snippets`
- All 963 tests pass

## Related

Follows up on PR #55 (`--format json` on individual check commands)