### PR TITLE
chore(dev): add Context7 MCP server config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ artifacts/
 .vscode/
 !.vscode/extensions.json
 !.vscode/settings.json
+!.vscode/mcp.json
 
 # IntelliJ IDEA / PyCharm
 .idea/

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+  "servers": {
+    "context7": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    }
+  }
+}

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -89,6 +89,11 @@ path = [".gitignore", ".markdownlint.json", ".pre-commit-config.yaml", ".pre-com
 SPDX-FileCopyrightText = "2026 PythonWoods <dev@pythonwoods.dev>"
 SPDX-License-Identifier = "Apache-2.0"
 
+[[annotations]]
+path = ".vscode/mcp.json"
+SPDX-FileCopyrightText = "2026 PythonWoods <dev@pythonwoods.dev>"
+SPDX-License-Identifier = "Apache-2.0"
+
 # ── CI ────────────────────────────────────────────────────────────────────────
 
 [[annotations]]


### PR DESCRIPTION
## Changes

- Add `.vscode/mcp.json` with Context7 MCP server for on-demand library
  documentation (Python tooling, Ruff, Mypy, Hypothesis, etc.) during development
- Update `.gitignore` to allow `.vscode/mcp.json` alongside the existing
  `settings.json` and `extensions.json` exceptions
- Add SPDX annotation for `.vscode/mcp.json` in `REUSE.toml`

## How to use Context7
Add `use context7` to any Copilot prompt, e.g.:
> "What are the Hypothesis `@given` strategies for collections? use context7"