### PR TITLE
chore: post-v0.7.0 integrity — guard removal + broken URL fixes (EN+IT)

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -496,11 +496,11 @@ Apache-2.0 — vedi [LICENSE][license].
 
 Zenzic è nato da un percorso tecnico attraverso la fragilità dei moderni ecosistemi di
 documentazione. Scopri la filosofia, l'assedio della sicurezza e l'ingegneria dietro il
-Sentinel nelle [**Engineering Chronicles**](https://zenzic.dev/blog/tags/engineering-chronicles) sul blog ufficiale.
+Sentinel nelle [**Engineering Chronicles**](https://zenzic.dev/blog/tags/chronicles) sul blog ufficiale.
 
 La storia della release v0.7.0 — l'assedio red-team guidato dall'IA, 4 vettori di bypass
 chiusi, e la strada verso la parità engine-agnostica — è documentata in
-[**Beyond the Siege: Zenzic v0.7.0**](https://zenzic.dev/blog/beyond-the-siege-zenzic-v070).
+[**Beyond the Siege: Zenzic v0.7.0**](https://zenzic.dev/blog/beyond-the-siege-zenzic-v070-quartz).
 
 ---
 
@@ -528,7 +528,7 @@ chiusi, e la strada verso la parità engine-agnostica — è documentata in
 [docs-it-home]:      https://zenzic.dev/it/docs/
 [docs-it-badges]:    https://zenzic.dev/it/docs/how-to/add-badges/
 [docs-it-cicd]:      https://zenzic.dev/it/docs/how-to/configure-ci-cd/
-[docs-it-arch]:      https://zenzic.dev/it/developers/explanation/
+[docs-it-arch]:      https://zenzic.dev/it/developers/explanation/engineering-ledger
 [docs-it-developers]: https://zenzic.dev/it/developers/
 [docs-it-adr-vault]: https://zenzic.dev/it/developers/explanation/adr-vault
 [docs-it-adr-011]:   https://zenzic.dev/it/developers/explanation/adr-cross-instance-allowlist

--- a/README.md
+++ b/README.md
@@ -491,11 +491,11 @@ Apache-2.0 — see [LICENSE][license].
 
 Zenzic was born from a technical journey through the fragility of modern documentation
 ecosystems. Discover the philosophy, the security siege, and the engineering behind the
-Sentinel in the [**Engineering Chronicles**](https://zenzic.dev/blog/tags/engineering-chronicles) on the official blog.
+Sentinel in the [**Engineering Chronicles**](https://zenzic.dev/blog/tags/chronicles) on the official blog.
 
 The v0.7.0 release story — AI-driven red-team siege, 4 bypass vectors closed, and the
 road to engine-agnostic parity — is documented in
-[**Beyond the Siege: Zenzic v0.7.0**](https://zenzic.dev/blog/beyond-the-siege-zenzic-v070).
+[**Beyond the Siege: Zenzic v0.7.0**](https://zenzic.dev/blog/beyond-the-siege-zenzic-v070-quartz).
 
 ---
 
@@ -523,7 +523,7 @@ road to engine-agnostic parity — is documented in
 [docs-home]:         https://zenzic.dev/docs/
 [docs-badges]:       https://zenzic.dev/docs/how-to/add-badges/
 [docs-cicd]:         https://zenzic.dev/docs/how-to/configure-ci-cd/
-[docs-arch]:         https://zenzic.dev/developers/explanation/
+[docs-arch]:         https://zenzic.dev/developers/explanation/engineering-ledger
 [docs-developers]:   https://zenzic.dev/developers/
 [docs-adr-vault]:    https://zenzic.dev/developers/explanation/adr-vault
 [docs-adr-011]:      https://zenzic.dev/developers/explanation/adr-cross-instance-allowlist

--- a/justfile
+++ b/justfile
@@ -37,15 +37,10 @@ sync:
 check *args:
     #!/usr/bin/env bash
     set -euo pipefail
-    # Pre-Launch Guard — remove after GA deploy when all URLs resolve
+    # Permanent exclusion: contributor-covenant.org is a flaky third-party URL.
     GUARD=(
-      --exclude-url "https://zenzic.dev/"
-      --exclude-url "https://github.com/PythonWoods/zenzic/releases/tag/v0.7.0"
       --exclude-url "https://www.contributor-covenant.org/version/2/1/code_of_conduct.html"
     )
-    if [[ ${#GUARD[@]} -gt 0 ]]; then
-      echo -e "\033[33m[QUARTZ WARNING] Pre-Launch Guard active: skipping internal/future URLs. DO NOT release with these guards active.\033[0m" >&2
-    fi
     {{ runner }} zenzic check all --strict "${GUARD[@]}" {{ args }}
 
 # Inner loop: ultra-fast, parallel, no coverage (TDD feedback).


### PR DESCRIPTION
Post-launch cleanup after `v0.7.0` tag and `zenzic.dev` deployment.

## Changes

**Guard removal** (`justfile`)
- Pre-Launch Guard array reduced to the single permanent exclusion:
  `contributor-covenant.org` (flaky third-party, not a deployment-gated URL).
- URLs removed: `https://zenzic.dev/`, `https://github.com/PythonWoods/zenzic/releases/tag/v0.7.0`.

**URL fixes** (`README.md`, `README.it.md`)
Three links were pointing to 404 paths before the site was live:
- `https://zenzic.dev/developers/explanation/` → `https://zenzic.dev/developers/explanation/engineering-ledger`
- `https://zenzic.dev/blog/tags/engineering-chronicles` → `https://zenzic.dev/blog/tags/chronicles`
- `https://zenzic.dev/blog/beyond-the-siege-zenzic-v070` → `https://zenzic.dev/blog/beyond-the-siege-zenzic-v070-quartz`

## Verification

`just check` → ✨ Sentinel Seal (0 errors, 0 warnings)