### PR TITLE
docs: readme parity and governance wording cleanup

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -211,9 +211,9 @@ Apache-2.0 — vedi [LICENSE][license].
 [docs-it-home]:      https://zenzic.dev/it/docs/
 [docs-it-badges]:    https://zenzic.dev/it/docs/how-to/add-badges/
 [docs-it-cicd]:      https://zenzic.dev/it/docs/how-to/configure-ci-cd/
-[docs-arch]:         https://zenzic.dev/developers/explanation/engineering-ledger
+[docs-arch]:         https://zenzic.dev/developers/how-to/implement-adapter
 [docs-developers]:   https://zenzic.dev/developers/
-[docs-eng-ledger]:   https://zenzic.dev/developers/explanation/engineering-ledger
+[docs-eng-ledger]:   https://zenzic.dev/developers/explanation/adr-vault
 [contributing]:      CONTRIBUTING.it.md
 [license]:           LICENSE
 [citation-cff]:      CITATION.cff

--- a/README.it.md
+++ b/README.it.md
@@ -62,14 +62,14 @@ dei file.
 ```bash
 pip install zenzic
 cd il-mio-repo-docs
-zenzic init       # Stabilisce il perimetro del workspace (crea zenzic.toml)
+zenzic init       # Stabilisce il perimetro del workspace (crea .zenzic.toml)
 zenzic check all  # Analizza la cartella corrente
 ```
 
 ## 🧠 Proposta di Valore
 
 - **Motore puro e deterministico:** input identici producono finding ed exit identici.
-- **Modello codici a tier:** finding Core, Structure e Governance separati per ownership, con cambi di policy espliciti e auditabili.
+- **Modello codici a tier:** finding Core, Structure e Governance raggruppati per tier.
 - **Contratti frozen per integrazioni:** `FROZEN_CODES`, `NON_SUPPRESSIBLE_CODES` e `PLUGIN_FORBIDDEN_EXITS` sono superfici stabili per CI e plugin.
 - **Workflow contributori inspect-first:** usare `zenzic inspect codes` prima di aggiornare esempi documentali o note di rilascio.
 
@@ -85,7 +85,7 @@ zenzic check all  # Analizza la cartella corrente
 | `zenzic check all [PATH]` | Audit documentazione completo — link, credenziali, orfani |
 | `zenzic score [--fail-under N] [--stamp]` | Calcola il Documentation Quality Score (0–100) |
 | `zenzic diff [--base PATH]` | Rileva regressioni di debito rispetto a una baseline salvata |
-| `zenzic guard scan [PATH]` | Pre-gate credenziali Defense-in-Depth (sempre fatale) |
+| `zenzic guard scan [PATH]` | Pre-gate credenziali Defense-in-Depth (fatale su finding di sicurezza: exit 2) |
 | `zenzic inspect codes` | Interroga la semantica live dei codici di errore e la loro sopprimibilità |
 
 ---
@@ -109,7 +109,7 @@ zenzic check all  # Analizza la cartella corrente
 
 | Motore | Adapter | Punti chiave |
 | :--- | :--- | :--- |
-| [Docusaurus v3][docusaurus] | `DocusaurusAdapter` | Versioned docs, alias `@site/`, Ghost Route detection |
+| [Docusaurus][docusaurus] | `DocusaurusAdapter` | Versioned docs, alias `@site/`, Ghost Route detection |
 | [MkDocs][mkdocs] | `MkDocsAdapter` | Modalità i18n suffix + folder, `fallback_to_default` |
 | [Zensical][zensical] | `ZensicalAdapter` | Proxy trasparente per `mkdocs.yml` |
 | Qualsiasi cartella | `StandaloneAdapter` | Controlli integrità — rilevamento orfani disabilitato senza contratto nav |
@@ -120,10 +120,10 @@ Vedi l'[Adapter API][docs-arch] per l'interfaccia plugin. I terzi adapter si ins
 
 ## ⚙️ Configurazione
 
-Zero-config per default. Vedi la [Guida alla Configurazione][docs-it-home] per lo schema completo di `zenzic.toml`.
+Zero-config per default. Vedi la [Guida alla Configurazione][docs-it-home] per lo schema completo di `.zenzic.toml` e l'embedding in `pyproject.toml`.
 
 ```bash
-zenzic init        # Genera zenzic.toml con valori auto-rilevati
+zenzic init        # Genera .zenzic.toml con valori auto-rilevati
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ file integrity.
 ```bash
 pip install zenzic
 cd my-docs-repo
-zenzic init       # Establish the workspace boundary (creates zenzic.toml)
+zenzic init       # Establish the workspace boundary (creates .zenzic.toml)
 zenzic check all  # Audit the current directory
 ```
 
 ## 🧠 Core Pillars
 
 - **Pure, deterministic engine:** identical inputs produce identical findings and exits.
-- **Tiered code model:** Core, Structure, and Governance findings separated by ownership bands.
+- **Tiered code model:** Core, Structure, and Governance findings grouped by tier.
 - **Frozen contracts for integrators:** `FROZEN_CODES`, `NON_SUPPRESSIBLE_CODES`, and `PLUGIN_FORBIDDEN_EXITS` provide stable enforcement surfaces for CI and plugins.
 - **Inspect-first workflow:** use `zenzic inspect codes` to validate live code semantics before touching docs or release notes.
 
@@ -85,7 +85,7 @@ zenzic check all  # Audit the current directory
 | `zenzic check all [PATH]` | Full documentation audit — links, credentials, orphans |
 | `zenzic score [--fail-under N] [--stamp]` | Compute the Documentation Quality Score (0–100) |
 | `zenzic diff [--base PATH]` | Detect debt regression against a saved baseline |
-| `zenzic guard scan [PATH]` | Defense-in-Depth credential pre-gate (always fatal) |
+| `zenzic guard scan [PATH]` | Defense-in-Depth credential pre-gate (fatal on security findings: exit 2) |
 | `zenzic inspect codes` | Query live error-code semantics and suppressibility |
 
 ---
@@ -109,7 +109,7 @@ zenzic check all  # Audit the current directory
 
 | Engine | Adapter | Highlights |
 | :--- | :--- | :--- |
-| [Docusaurus v3][docusaurus] | `DocusaurusAdapter` | Versioned docs, `@site/` alias, Ghost Route detection |
+| [Docusaurus][docusaurus] | `DocusaurusAdapter` | Versioned docs, `@site/` alias, Ghost Route detection |
 | [MkDocs][mkdocs] | `MkDocsAdapter` | i18n suffix + folder modes, `fallback_to_default` |
 | [Zensical][zensical] | `ZensicalAdapter` | Transparent Proxy bridges `mkdocs.yml` |
 | Any folder | `StandaloneAdapter` | File integrity checks — orphan detection disabled without a nav contract |
@@ -120,10 +120,10 @@ See the [Adapter API][docs-arch] for the plugin interface. Third-party adapters 
 
 ## ⚙️ Configuration
 
-Zero-config by default. See the [Configuration Guide][docs-home] for the full `zenzic.toml` schema and `pyproject.toml` embedding.
+Zero-config by default. See the [Configuration Guide][docs-home] for the full `.zenzic.toml` schema and `pyproject.toml` embedding.
 
 ```bash
-zenzic init        # Generate zenzic.toml with auto-detected values
+zenzic init        # Generate .zenzic.toml with auto-detected values
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -211,9 +211,9 @@ Apache-2.0 — see [LICENSE][license].
 [docs-home]:         https://zenzic.dev/docs/
 [docs-badges]:       https://zenzic.dev/docs/how-to/add-badges/
 [docs-cicd]:         https://zenzic.dev/docs/how-to/configure-ci-cd/
-[docs-arch]:         https://zenzic.dev/developers/explanation/engineering-ledger
+[docs-arch]:         https://zenzic.dev/developers/how-to/implement-adapter
 [docs-developers]:   https://zenzic.dev/developers/
-[docs-eng-ledger]:   https://zenzic.dev/developers/explanation/engineering-ledger
+[docs-eng-ledger]:   https://zenzic.dev/developers/explanation/adr-vault
 [contributing]:      CONTRIBUTING.md
 [license]:           LICENSE
 [citation-cff]:      CITATION.cff


### PR DESCRIPTION
## Summary\n- align EN/IT README governance wording and exit semantics\n- repair broken developer reference links\n- preserve release automation-managed version literals where required\n\n## Validation\n- pre-commit hooks\n- just verify (pre-push guard)