### PR TITLE
fix(brand): align release codenames to Diamond and retire Graphite

### DIFF
--- a/.zenzic.toml
+++ b/.zenzic.toml
@@ -76,7 +76,7 @@ default_locale = "en"
 
 # --- BRAND INTEGRITY ---
 [project_metadata]
-release_name = "Graphite"
+release_name = "Diamond"
 obsolete_names_exclude_patterns = ["CHANGELOG*.md", "CHANGELOG*.archive.md", "changelogs/*.md", "RELEASE.md"]
 badge_stamp_files = ["README.md", "README.it.md"]
 
@@ -97,6 +97,7 @@ suppression_cap_fail_hard = true
 
 # Terms that should no longer appear in your documentation.
 brand_obsolescence = [
+    "Graphite",
     "Quartz",
     "Obsidian",
     "Basalt",
@@ -132,6 +133,7 @@ brand_obsolescence = [
 "changelogs/**" = ["Z601"]  # historical release codenames (Obsidian, Quartz…)
 "CHANGELOG*.md" = ["Z601"]  # release codenames in historical changelogs
 "RELEASE.md"    = ["Z601"]  # current release codename tracking
+"ROADMAP.md"    = ["Z601"]  # historical/planned codenames in roadmap
 
 # Governance Playbook:
 # https://zenzic.dev/developers/how-to/release-governance-protocol

--- a/.zenzic.toml
+++ b/.zenzic.toml
@@ -76,7 +76,7 @@ default_locale = "en"
 
 # --- BRAND INTEGRITY ---
 [project_metadata]
-release_name = "Diamond"
+release_name = "Magnetite"
 obsolete_names_exclude_patterns = ["CHANGELOG*.md", "CHANGELOG*.archive.md", "changelogs/*.md", "RELEASE.md"]
 badge_stamp_files = ["README.md", "README.it.md"]
 
@@ -97,10 +97,10 @@ suppression_cap_fail_hard = true
 
 # Terms that should no longer appear in your documentation.
 brand_obsolescence = [
-    "Graphite",
+    "Basalt",
     "Quartz",
     "Obsidian",
-    "Basalt",
+    "Graphite"
 ]
 # suppression_cap_scope = "all"  # Options: all, per-file
 # i18n_parity = false            # Set true when i18n is enabled

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@
 | Field    | Value      |
 | :------- | :--------- |
 | Version  | v0.10.0     |
-| Codename | Diamond   |
+| Codename | Magnetite   |
 | Date     | 2026-06-06 |
 | Status   | Stable |
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@
 | Field    | Value      |
 | :------- | :--------- |
 | Version  | v0.10.0     |
-| Codename | Graphite   |
+| Codename | Diamond   |
 | Date     | 2026-06-06 |
 | Status   | Stable |
 


### PR DESCRIPTION
Update release metadata, retire Graphite, and align roadmap to Diamond codename.