### PR TITLE
fix(test): exclude ZenzicConfig default excluded dirs from hypothesis generation

### DIFF
--- a/tests/test_i18n_parity.py
+++ b/tests/test_i18n_parity.py
@@ -237,7 +237,11 @@ _PATH_SEGMENT = st.text(
     max_size=12,
 ).filter(
     lambda s: (
-        s not in (".", "..") and "/" not in s and "\\" not in s and s not in SYSTEM_EXCLUDED_DIRS
+        s not in (".", "..")
+        and "/" not in s
+        and "\\" not in s
+        and s not in SYSTEM_EXCLUDED_DIRS
+        and s not in {"includes", "stylesheets", "overrides"}
     )
 )
 


### PR DESCRIPTION
Fixes a flaky test failure in CI where hypothesis generated the `stylesheets` segment, which is implicitly ignored by `ZenzicConfig` default exclusions.