### PR TITLE
fix(cli): apply governance suppressions before SARIF export

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tool.bumpversion]
-current_version = "0.13.0"
+current_version = "0.13.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}{pre_l}{pre_n}",

--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Zenzic version
       description: Output of `zenzic --version`
-      placeholder: "0.13.0"
+      placeholder: "0.13.1"
     validations:
       required: true
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 #
 #   repos:
 #     - repo: https://github.com/PythonWoods/zenzic
-#       rev: v0.13.0
+#       rev: v0.13.1
 #       hooks:
 #         - id: zenzic-verify    # quality gate — corrisponde a `just verify` lato zenzic
 #         - id: zenzic-guard     # fast staged-file credential scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.13.1] - 2026-06-19
+
+### Fixed
+
+- **SARIF Formatter Bypass:** Fixed a critical bug in `check` where the SARIF JSON output bypassed `per_file_ignores` and `directory_policies` filtering. Zenzic now correctly applies governance exclusions to the SARIF output, ensuring only active (unsuppressed) findings are exported to GitHub Advanced Security.
+
+---
+
 ## [0.13.0] - 2026-06-19
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ abstract: >-
   performs deterministic static analysis using a two-pass reference
   pipeline and a RE2-backed credential scanner, with zero subprocess
   calls and full SARIF 2.1.0 support for CI/CD integration.
-version: 0.13.0
+version: 0.13.1
 date-released: 2026-06-19
 url: "https://zenzic.dev"
 repository-code: "https://github.com/PythonWoods/zenzic"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,9 +8,9 @@
 
 | Field    | Value      |
 | :------- | :--------- |
-| Version  | v0.13.0     |
+| Version  | v0.13.1     |
 | Codename | Magnetite   |
-| Date     | 2026-06-17 |
+| Date     | 2026-06-19 |
 | Status   | Stable |
 
 ## Release Checklist
@@ -21,7 +21,7 @@ Before tagging, every item must be green:
 - [ ] `zenzic lab all` — all 20 scenarios exit with expected code
 - [ ] `zenzic score --stamp` committed — badge in README.md reflects current score
 - [ ] `zenzic check all .` — zero findings in the repo root
-- [ ] `pyproject.toml` version matches the tag (`0.13.0`)
+- [ ] `pyproject.toml` version matches the tag (`0.13.1`)
 - [ ] `CITATION.cff` version and date updated
 - [ ] `CHANGELOG.md` — `[Unreleased]` section moved to the new version heading
 - [ ] Update SECURITY.md support table (Add new release, demote previous to Critical/EOL).
@@ -54,11 +54,11 @@ git checkout main
 git pull origin main
 
 # 3. Tag the main branch and push
-git tag v0.13.0
+git tag v0.13.1
 git push origin main --tags
 ```
 
-- [ ] Create GitHub Release from the tag, using the `## v0.13.0` CHANGELOG section as the release body.
+- [ ] Create GitHub Release from the tag, using the `## v0.13.1` CHANGELOG section as the release body.
 
 ## Changelog Reference
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zenzic"
-version = "0.13.0"
+version = "0.13.1"
 description = "Engineering-grade, engine-agnostic static analyzer and credential scanner for Markdown documentation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/zenzic/__init__.py
+++ b/src/zenzic/__init__.py
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """Zenzic — engine-agnostic static analyzer and credential scanner for Markdown documentation."""
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 __version_name__ = "Basalt"  # Release codename stored separately from the package version.

--- a/src/zenzic/cli/_check.py
+++ b/src/zenzic/cli/_check.py
@@ -1583,6 +1583,8 @@ def check_all(
 
         with sovereign_context(force_audit=audit):
             all_findings = _to_findings(results, docs_root, repo_root)
+            all_findings = _apply_per_file_ignores(all_findings, config)
+            all_findings = _apply_directory_policies(all_findings, config)
         _shared._output_sarif_findings(all_findings, __version__)
         incidents = sum(1 for f in all_findings if f.severity == "security_incident")
         if incidents:

--- a/src/zenzic/cli/_standalone.py
+++ b/src/zenzic/cli/_standalone.py
@@ -1581,7 +1581,7 @@ version = "0.1.0"
 description = "Custom Zenzic plugin rule package"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["zenzic>=0.13.0"]
+dependencies = ["zenzic>=0.13.1"]
 
 [project.entry-points."zenzic.rules"]
 {project_slug} = "{module_name}.rules:{class_name}"

--- a/uv.lock
+++ b/uv.lock
@@ -2163,7 +2163,7 @@ wheels = [
 
 [[package]]
 name = "zenzic"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-re2" },


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in the SARIF formatter where the output bypassed the `per_file_ignores` and `directory_policies` filtering. 

Previously, when running `zenzic check all --format sarif`, the raw findings were directly converted to SARIF without calling `_apply_per_file_ignores()` and `_apply_directory_policies()`. This exposed all internal suppressed issues to GitHub Advanced Security, effectively breaking the CI pipeline despite the issues being properly managed and suppressed in `.zenzic.toml`.

## Changes
- Applied sovereign governance context (`_apply_per_file_ignores` and `_apply_directory_policies`) to the findings array before calling `_output_sarif_findings` in `src/zenzic/cli/_check.py`.
- Bumped project version to `v0.13.1` across all manifests and documentation, including `CITATION.cff`.

## Impact
- **Managed Debt Correctness:** The SARIF output now aligns with `text` and `github-annotations` formats, respecting the repository's configured technical debt.
- **Zero-Debt Compliance:** Allows CI pipelines using `upload-sarif: 'true'` to run without failing on explicitly suppressed files (e.g. legacy blog posts with i18n parity exemptions).