### PR TITLE
fix(governance): synchronize version metadata for 0.16.0

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tool.bumpversion]
-current_version = "0.15.1"
+current_version = "0.16.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}{pre_l}{pre_n}",

--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Zenzic version
       description: Output of `zenzic --version`
-      placeholder: "0.15.1"
+      placeholder: "0.16.0"
     validations:
       required: true
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 #
 #   repos:
 #     - repo: https://github.com/PythonWoods/zenzic
-#       rev: v0.15.1
+#       rev: v0.16.0
 #       hooks:
 #         - id: zenzic-verify    # quality gate — corrisponde a `just verify` lato zenzic
 #         - id: zenzic-guard     # fast staged-file credential scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [0.16.0] - Unreleased
+## [0.16.0] - 2026-06-27
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [0.15.1] - Unreleased
+## [0.16.0] - Unreleased
 
 ### Added
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -28,7 +28,6 @@ keywords:
   - markdown
   - security-auditing
   - re2
-  - docusaurus
   - mkdocs
 references:
   - type: website
@@ -37,4 +36,4 @@ references:
     repository-code: "https://github.com/PythonWoods/zenzic-doc"
     abstract: >-
       Official Diátaxis documentation corpus for Zenzic, covering tutorials,
-      how-to guides, reference, and explanation — available in English and Italian.
+      how-to guides, reference, and explanation — available in English.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ abstract: >-
   performs deterministic static analysis using a two-pass reference
   pipeline and a RE2-backed credential scanner, with zero subprocess
   calls and full SARIF 2.1.0 support for CI/CD integration.
-version: 0.15.1
-date-released: 2026-06-22
+version: 0.16.0
+date-released: 2026-06-27
 url: "https://zenzic.dev"
 repository-code: "https://github.com/PythonWoods/zenzic"
 repository-artifact: "https://pypi.org/project/zenzic/"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,9 +8,9 @@
 
 | Field    | Value      |
 | :------- | :--------- |
-| Version  | v0.15.1     |
+| Version  | v0.16.0     |
 | Codename | Magnetite   |
-| Date     | 2026-06-22 |
+| Date     | 2026-06-27 |
 | Status   | Stable |
 
 ## Release Checklist
@@ -21,7 +21,7 @@ Before tagging, every item must be green:
 - [ ] `zenzic lab all` — all 20 scenarios exit with expected code
 - [ ] `zenzic score --stamp` committed — badge in README.md reflects current score
 - [ ] `zenzic check all .` — zero findings in the repo root
-- [ ] `pyproject.toml` version matches the tag (`0.15.1`)
+- [ ] `pyproject.toml` version matches the tag (`0.16.0`)
 - [ ] `CITATION.cff` version and date updated
 - [ ] `CHANGELOG.md` — `[Unreleased]` section moved to the new version heading
 - [ ] Update SECURITY.md support table (Add new release, demote previous to Critical/EOL).
@@ -54,11 +54,11 @@ git checkout main
 git pull origin main
 
 # 3. Tag the main branch and push
-git tag v0.15.1
+git tag v0.16.0
 git push origin main --tags
 ```
 
-- [ ] Create GitHub Release from the tag, using the `## v0.15.1` CHANGELOG section as the release body.
+- [ ] Create GitHub Release from the tag, using the `## v0.16.0` CHANGELOG section as the release body.
 
 ## Changelog Reference
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -180,7 +180,7 @@ extra:
   # ADR-037: No hardcoded SemVer in any .html or .md source.
   # CI pipeline passes the current version at build time, e.g.:
   #   uv run mkdocs build --extra zenzic_version=0.14.1
-  zenzic_version: "0.15.1"  # release sync
+  zenzic_version: "0.16.0"  # release sync
 
 markdown_extensions:
   - attr_list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zenzic"
-version = "0.15.1"
+version = "0.16.0"
 description = "Engineering-grade, engine-agnostic static analyzer and credential scanner for Markdown documentation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/zenzic/__init__.py
+++ b/src/zenzic/__init__.py
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """Zenzic — engine-agnostic static analyzer and credential scanner for Markdown documentation."""
 
-__version__ = "0.15.1"
+__version__ = "0.16.0"
 __version_name__ = "Basalt"  # Release codename stored separately from the package version.

--- a/src/zenzic/cli/_standalone.py
+++ b/src/zenzic/cli/_standalone.py
@@ -1585,7 +1585,7 @@ version = "0.1.0"
 description = "Custom Zenzic plugin rule package"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["zenzic>=0.15.1"]
+dependencies = ["zenzic>=0.16.0"]
 
 [project.entry-points."zenzic.rules"]
 {project_slug} = "{module_name}.rules:{class_name}"

--- a/uv.lock
+++ b/uv.lock
@@ -2383,7 +2383,7 @@ wheels = [
 
 [[package]]
 name = "zenzic"
-version = "0.15.1"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-re2" },


### PR DESCRIPTION
Bump version to 0.16.0, remove obsolete docusaurus tags, update language scope in citation, and finalize changelog release date.