### PR TITLE
fix(docs): add missing legacy redirects and fix RSS stylesheet 404

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -31,11 +31,17 @@
 /developers/explanation/adr-bilingual-structural         /developers/explanation/adr-vault/records/adr-bilingual-structural/ 301
 /developers/explanation/adr-sovereign-sandbox            /developers/explanation/adr-vault/records/adr-007-sovereign-sandbox/ 301
 /developers/explanation/adr-zero-subprocesses            /developers/explanation/adr-vault/records/adr-002-zero-subprocesses/ 301
+/developers/how-to/adapter-examples/                     /developers/how-to/implement-adapter/ 301
+/developers/how-to/adapter-examples                      /developers/how-to/implement-adapter/ 301
 
 # ─── LAYER 3: BLOG CANONICAL SLUGS ───────────────────────────────────────────
 /blog/welcome                                 /blog/2026/04/28/welcome-to-the-zenzic-blog/ 301
 /blog/welcome/                                /blog/2026/04/28/welcome-to-the-zenzic-blog/ 301
 /blog/zenzic-v0160-engineering-determinism-into-documentation-pipelines /blog/2026/06/27/zenzic-v0160-engineering-determinism-into-documentation-pipelines/ 301
+/blog/obsidian-masterclass/                   /blog/2026/05/24/engineering-v080-deep-dive/ 301
+/blog/obsidian-masterclass                    /blog/2026/05/24/engineering-v080-deep-dive/ 301
+/blog/rss.xsl                                 /rss.xsl 301
+/blog/atom.xsl                                /rss.xsl 301
 
 # ─── LAYER 4: STRUCTURAL MIRRORS (Known Folders) ─────────────────────────────
 /it/blog/*                                    /blog/ 301


### PR DESCRIPTION
Resolves 404 errors for legacy adapter examples and obsidian masterclass blog posts. Also adds explicit redirect for blog/rss.xsl to the root rss.xsl to prevent XML parser errors in RSS feeds.