### PR TITLE
fix(docs): configure rss plugin to strip html and use brand logo

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -31,11 +31,17 @@
 /developers/explanation/adr-bilingual-structural         /developers/explanation/adr-vault/records/adr-bilingual-structural/ 301
 /developers/explanation/adr-sovereign-sandbox            /developers/explanation/adr-vault/records/adr-007-sovereign-sandbox/ 301
 /developers/explanation/adr-zero-subprocesses            /developers/explanation/adr-vault/records/adr-002-zero-subprocesses/ 301
+/developers/how-to/adapter-examples/                     /developers/how-to/implement-adapter/ 301
+/developers/how-to/adapter-examples                      /developers/how-to/implement-adapter/ 301
 
 # ─── LAYER 3: BLOG CANONICAL SLUGS ───────────────────────────────────────────
 /blog/welcome                                 /blog/2026/04/28/welcome-to-the-zenzic-blog/ 301
 /blog/welcome/                                /blog/2026/04/28/welcome-to-the-zenzic-blog/ 301
 /blog/zenzic-v0160-engineering-determinism-into-documentation-pipelines /blog/2026/06/27/zenzic-v0160-engineering-determinism-into-documentation-pipelines/ 301
+/blog/obsidian-masterclass/                   /blog/2026/05/24/engineering-v080-deep-dive/ 301
+/blog/obsidian-masterclass                    /blog/2026/05/24/engineering-v080-deep-dive/ 301
+/blog/rss.xsl                                 /rss.xsl 301
+/blog/atom.xsl                                /rss.xsl 301
 
 # ─── LAYER 4: STRUCTURAL MIRRORS (Known Folders) ─────────────────────────────
 /it/blog/*                                    /blog/ 301

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -217,6 +217,11 @@ plugins:
       match_path: "blog/posts/.*"
       date_from_meta:
         as_creation: date
+      use_material_blog: true
+      use_material_social_cards: true
+      abstract_chars_count: 160
+      abstract_delimiter: <!-- more -->
+      image: https://zenzic.dev/assets/brand/svg/zenzic-icon.svg
       feeds_filenames:
         rss_created: blog/rss.xml
         rss_updated: blog/atom.xml


### PR DESCRIPTION
RSS feeds were rendering raw HTML in the description and failing to parse the image fallback. This patch configures the mkdocs-rss-plugin to properly extract pure abstracts and link the brand SVG.