### PR TITLE
fix(docs): resolve obsolete /docs/ URLs in metadata and templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
 ## [0.19.2] — 2026-07-02
 
 ### Fixed
+
 - **Performance (LCP):** Optimized Critical Rendering Path by injecting `<link rel="preconnect">` resource hints for the GitHub API, significantly reducing latency for client-side widgets.
 - **Performance (CSS):** Implemented strict Tailwind CSS purging via `tailwind.config.js`, removing unused utility classes and minimizing the frontend payload.
 
 ### Technical Details
+
 - **DQS Invariant:** Repository Documentation Quality Score remains verified at 100/100.
 
 ## [0.19.1] - 2026-07-02

--- a/changelogs/v0.7-docs-archive.md
+++ b/changelogs/v0.7-docs-archive.md
@@ -187,7 +187,7 @@ Archive of release notes extracted from the main changelog.
   Sovereign Override shield was active in CI but not locally.
 - **ZENZIC_EXTRA_ARGS CI propagation**: `.github/workflows/ci.yml` injects
   five `--exclude-url` entries for known pre-launch transient URLs
-  (`zenzic.dev/blog/`, `zenzic.dev/docs/explanation/structural-integrity`,
+  (`zenzic.dev/blog/`, `zenzic.dev/explanation/structural-integrity`,
   `zenzic.dev/developers/`, `zenzic.dev/it/developers/`, and the
   `v0.7.0` GitHub release tag). `PYTHONUTF8: '1'` added for Windows encoding
   determinism.

--- a/overrides/partials/homepage/execution_layer.html
+++ b/overrides/partials/homepage/execution_layer.html
@@ -66,7 +66,7 @@
         <div class="space-y-1.5">
           <div>Summary: <span class="text-rose-500">✘ 1 security breach</span>  <span class="text-rose-500">✘ 2 errors</span>  <span class="text-amber-500">⚠ 4 warnings</span>  <span class="dark:text-zinc-400 text-zinc-600">💡 0 info</span>  <span class="dark:text-zinc-400 text-zinc-600">• 3 files with findings</span></div>
           <div class="text-rose-500 font-semibold tracking-wide">FAILED: Hard errors detected. Exit code 1 is mandatory.</div>
-          <div class="dark:text-zinc-400 text-zinc-600">Refer to https://zenzic.dev/docs/reference/finding-codes for remediation · Try 'zenzic check --help' for options.</div>
+          <div class="dark:text-zinc-400 text-zinc-600">Refer to https://zenzic.dev/reference/finding-codes for remediation · Try 'zenzic check --help' for options.</div>
           <div class="dark:text-zinc-400 text-zinc-600">🔒 Suppression Audit: 0/30 (inline: 0, per-file: 0)</div>
         </div>
       </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ broken-links = "zenzic.core.rules:VSMBrokenLinkRule"
 
 [project.urls]
 Homepage      = "https://zenzic.dev"
-Documentation = "https://zenzic.dev/docs/"
+Documentation = "https://zenzic.dev/"
 Repository    = "https://github.com/PythonWoods/zenzic"
 Source        = "https://github.com/PythonWoods/zenzic"
 Changelog     = "https://github.com/PythonWoods/zenzic/blob/main/CHANGELOG.md"


### PR DESCRIPTION
Resolves obsolete /docs/ URLs in metadata and templates under ZEN-v020-METADATA-CLEANUP and ZEN-v020-DEEP-LINK-AUDIT. Verification checks passed.