### PR TITLE
fix(lsp): decouple URP for in-memory validation and refactor Z403 Body markdown

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tool.bumpversion]
-current_version = "0.22.1"
+current_version = "0.22.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}{pre_l}{pre_n}",

--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Zenzic version
       description: Output of `zenzic --version`
-      placeholder: "0.22.1"
+      placeholder: "0.22.2"
     validations:
       required: true
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 #
 #   repos:
 #     - repo: https://github.com/PythonWoods/zenzic
-#       rev: v0.22.1
+#       rev: v0.22.2
 #       hooks:
 #         - id: zenzic-verify    # quality gate — corrisponde a `just verify` lato zenzic
 #         - id: zenzic-guard     # fast staged-file credential scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **ZLS Architecture:** Completely decoupled the Uniform Resolver Pipeline (URP) to support in-memory document validation. The Language Server now guarantees 100% diagnostic parity with the CLI for structural link checks (Z102, Z104, Z105) without redundant disk I/O.
+- **Rule Unification:** Refactored `Z403` (Missing Alt Text) into a native `BaseRule` to eliminate legacy hardcoded execution paths.
+
 ## [0.22.1] - 2026-07-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.22.2] - 2026-07-14
+
 ### Fixed
 
 - **ZLS Architecture:** Completely decoupled the Uniform Resolver Pipeline (URP) to support in-memory document validation. The Language Server now guarantees 100% diagnostic parity with the CLI for structural link checks (Z102, Z104, Z105) without redundant disk I/O.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ abstract: >-
   performs deterministic static analysis using a two-pass reference
   pipeline and a RE2-backed credential scanner, with zero subprocess
   calls and full SARIF 2.1.0 support for CI/CD integration.
-version: 0.22.1
+version: 0.22.2
 date-released: 2026-07-14
 url: "https://zenzic.dev"
 repository-code: "https://github.com/PythonWoods/zenzic"

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Zenzic Core is headless and emits standardized **SARIF** (Static Analysis Result
       "tool": {
         "driver": {
           "name": "zenzic",
-          "version": "0.22.1",
+          "version": "0.22.2",
           "rules": [
             {
               "id": "Z101",

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@
 
 | Field    | Value      |
 | :------- | :--------- |
-| Version  | v0.22.1     |
+| Version  | v0.22.2     |
 | Codename | Magnetite   |
 | Date     | 2026-07-14 |
 | Status   | Stable |
@@ -21,7 +21,7 @@ Before tagging, every item must be green:
 - [ ] `zenzic lab all` — all 20 scenarios exit with expected code
 - [ ] `zenzic score --stamp` committed — badge in README.md reflects current score
 - [ ] `zenzic check all .` — zero findings in the repo root
-- [ ] `pyproject.toml` version matches the tag (`0.22.1`)
+- [ ] `pyproject.toml` version matches the tag (`0.22.2`)
 - [ ] `CITATION.cff` version and date updated
 - [ ] `CHANGELOG.md` — `[Unreleased]` section moved to the new version heading
 - [ ] Update SECURITY.md support table (Add new release, demote previous to Critical/EOL).
@@ -53,11 +53,11 @@ git checkout main
 git pull origin main
 
 # 3. Tag the main branch and push
-git tag v0.22.1
+git tag v0.22.2
 git push origin main --tags
 ```
 
-- [ ] Create GitHub Release from the tag, using the `## [0.22.1]` CHANGELOG section as the release body.
+- [ ] Create GitHub Release from the tag, using the `## [0.22.2]` CHANGELOG section as the release body.
 
 ## Changelog Reference
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -201,7 +201,7 @@ extra:
   # ADR-037: No hardcoded SemVer in any .html or .md source.
   # CI pipeline passes the current version at build time, e.g.:
   #   uv run mkdocs build --extra zenzic_version=0.14.1
-  zenzic_version: "0.22.1"  # release sync
+  zenzic_version: "0.22.2"  # release sync
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/PythonWoods/zenzic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zenzic"
-version = "0.22.1"
+version = "0.22.2"
 description = "Engineering-grade, engine-agnostic static analyzer and credential scanner for Markdown documentation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/zenzic/__init__.py
+++ b/src/zenzic/__init__.py
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """Zenzic — engine-agnostic static analyzer and credential scanner for Markdown documentation."""
 
-__version__ = "0.22.1"
+__version__ = "0.22.2"
 __version_name__ = "Basalt"  # Release codename stored separately from the package version.

--- a/src/zenzic/cli/_standalone.py
+++ b/src/zenzic/cli/_standalone.py
@@ -1588,7 +1588,7 @@ version = "0.1.0"
 description = "Custom Zenzic plugin rule package"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["zenzic>=0.22.1"]
+dependencies = ["zenzic>=0.22.2"]
 
 [project.entry-points."zenzic.rules"]
 {project_slug} = "{module_name}.rules:{class_name}"

--- a/src/zenzic/core/rules.py
+++ b/src/zenzic/core/rules.py
@@ -1133,6 +1133,57 @@ class EmptyLinkRule(BaseRule):
         return findings
 
 
+class MissingAltTextRule(BaseRule):
+    """Z403: Inline Markdown images and HTML <img> tags must have alt text."""
+
+    @property
+    def rule_id(self) -> str:
+        return "Z403"
+
+    def check(self, file_path: Path, text: str) -> list[RuleFinding]:
+        from zenzic.core.scanner import _RE_IMAGE_INLINE, _RE_HTML_IMG, _RE_HTML_ALT
+        
+        findings = []
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            clean = _INLINE_CODE_RE.sub(lambda m: " " * len(m.group()), line)
+
+            # Inline Markdown images
+            for m in _RE_IMAGE_INLINE.finditer(clean):
+                alt_text = m.group(1)
+                url = m.group(2)
+                if not alt_text.strip():
+                    findings.append(
+                        RuleFinding(
+                            rule_id="Z403",
+                            severity="warning",
+                            file_path=file_path,
+                            line_no=lineno,
+                            message=f"Image '{url}' has no alt text.",
+                            matched_line=line,
+                        )
+                    )
+
+            # HTML <img> tags
+            for img_match in _RE_HTML_IMG.finditer(clean):
+                tag = img_match.group()
+                alt_match = _RE_HTML_ALT.search(tag)
+                src = tag  # fallback
+                if alt_match is None or not alt_match.group(1).strip():
+                    findings.append(
+                        RuleFinding(
+                            rule_id="Z403",
+                            severity="warning",
+                            file_path=file_path,
+                            line_no=lineno,
+                            message=f"HTML <img> tag has no alt text: {src[:60]}",
+                            matched_line=line,
+                        )
+                    )
+
+        return findings
+
+
+
 class VSMBrokenLinkRule(BaseRule):
     """VSM-aware broken link detector (🔌 Dev 3).
 

--- a/src/zenzic/core/rules.py
+++ b/src/zenzic/core/rules.py
@@ -1141,8 +1141,8 @@ class MissingAltTextRule(BaseRule):
         return "Z403"
 
     def check(self, file_path: Path, text: str) -> list[RuleFinding]:
-        from zenzic.core.scanner import _RE_IMAGE_INLINE, _RE_HTML_IMG, _RE_HTML_ALT
-        
+        from zenzic.core.scanner import _RE_HTML_ALT, _RE_HTML_IMG, _RE_IMAGE_INLINE
+
         findings = []
         for lineno, line in enumerate(text.splitlines(), start=1):
             clean = _INLINE_CODE_RE.sub(lambda m: " " * len(m.group()), line)
@@ -1181,7 +1181,6 @@ class MissingAltTextRule(BaseRule):
                     )
 
         return findings
-
 
 
 class VSMBrokenLinkRule(BaseRule):

--- a/src/zenzic/core/scanner.py
+++ b/src/zenzic/core/scanner.py
@@ -935,7 +935,6 @@ class ReferenceScanner:
 
             # Alt-text checking is now delegated to MissingAltTextRule (Z403)
 
-
         # Yield all events in line-number order
         yield from sorted(credential_events + content_events, key=lambda e: e[0])
 
@@ -1174,8 +1173,8 @@ def _build_rule_engine(config: ZenzicConfig) -> AdaptiveRuleEngine | None:
         CredentialScannerRule,
         CustomRule,
         EmptyLinkRule,
-        MissingAltTextRule,
         MalformedFrontmatterRule,
+        MissingAltTextRule,
         PluginRegistry,
         UntaggedCodeBlockRule,
     )

--- a/src/zenzic/core/scanner.py
+++ b/src/zenzic/core/scanner.py
@@ -819,65 +819,6 @@ def _iter_content_lines(
             yield lineno, line
 
 
-def check_image_alt_text(
-    text: str,
-    file_path: Path | str,
-) -> list[ReferenceFinding]:
-    """Pure function: find images that are missing alt text.
-
-    Checks both inline Markdown images ``![alt](url)`` and HTML ``<img>`` tags.
-    An empty alt attribute (``alt=""``) is treated as intentionally decorative
-    and is *not* flagged — the issue is a completely absent or blank alt string.
-
-    Args:
-        text: Raw Markdown content.
-        file_path: Path identifier for labelling findings (no disk access).
-
-    Returns:
-        List of :class:`ReferenceFinding` with ``issue="missing-alt"`` and
-        ``is_warning=True`` for every offending image.
-    """
-    path = Path(file_path)
-    findings: list[ReferenceFinding] = []
-
-    for lineno, line in enumerate(text.splitlines(), start=1):
-        # Blank out inline code to avoid false matches
-        clean = _INLINE_CODE_RE.sub(lambda m: " " * len(m.group()), line)
-
-        # Inline Markdown images
-        for m in _RE_IMAGE_INLINE.finditer(clean):
-            alt_text = m.group(1)
-            url = m.group(2)
-            if not alt_text.strip():
-                findings.append(
-                    ReferenceFinding(
-                        file_path=path,
-                        line_no=lineno,
-                        issue="Z403",
-                        detail=f"Image '{url}' has no alt text.",
-                        is_warning=True,
-                    )
-                )
-
-        # HTML <img> tags
-        for img_match in _RE_HTML_IMG.finditer(clean):
-            tag = img_match.group()
-            alt_match = _RE_HTML_ALT.search(tag)
-            src = tag  # fallback label when src is hard to extract
-            if alt_match is None or not alt_match.group(1).strip():
-                findings.append(
-                    ReferenceFinding(
-                        file_path=path,
-                        line_no=lineno,
-                        issue="Z403",
-                        detail=f"HTML <img> tag has no alt text: {src[:60]}",
-                        is_warning=True,
-                    )
-                )
-
-    return findings
-
-
 class ReferenceScanner:
     """Per-file stateful scanner implementing the Three-Phase Reference Pipeline.
 
@@ -905,7 +846,7 @@ class ReferenceScanner:
         self.file_path = file_path
         self.ref_map: ReferenceMap = ReferenceMap()
         self._config = config or ZenzicConfig()
-        self.missing_alts: list[ReferenceFinding] = []
+        self.suspicious_domains: list[ReferenceFinding] = []
 
     # ── Pass 1: Harvesting & Credential Scanner ────────────────────────────────
 
@@ -992,41 +933,8 @@ class ReferenceScanner:
                     content_events.append((lineno, "DUPLICATE_DEF", (norm_id, url)))
                 continue
 
-            # ── Alt-text: inline images ───────────────────────────────────────
-            clean = _INLINE_CODE_RE.sub(lambda m: " " * len(m.group()), line)
-            for img_match in _RE_IMAGE_INLINE.finditer(clean):
-                alt_text = img_match.group(1)
-                url = img_match.group(2)
-                if alt_text.strip():
-                    content_events.append((lineno, "IMG", (alt_text, url)))
-                else:
-                    content_events.append((lineno, "MISSING_ALT", url))
-                    self.missing_alts.append(
-                        ReferenceFinding(
-                            file_path=self.file_path,
-                            line_no=lineno,
-                            issue="Z403",
-                            detail=f"Image '{url}' has no alt text.",
-                            is_warning=True,
-                        )
-                    )
+            # Alt-text checking is now delegated to MissingAltTextRule (Z403)
 
-            # ── Alt-text: HTML <img> tags ─────────────────────────────────────
-            for img_match in _RE_HTML_IMG.finditer(clean):
-                tag = img_match.group()
-                alt_match = _RE_HTML_ALT.search(tag)
-                src = tag
-                if alt_match is None or not alt_match.group(1).strip():
-                    content_events.append((lineno, "MISSING_ALT", src))
-                    self.missing_alts.append(
-                        ReferenceFinding(
-                            file_path=self.file_path,
-                            line_no=lineno,
-                            issue="Z403",
-                            detail=f"HTML <img> tag has no alt text: {src[:60]}",
-                            is_warning=True,
-                        )
-                    )
 
         # Yield all events in line-number order
         yield from sorted(credential_events + content_events, key=lambda e: e[0])
@@ -1131,7 +1039,7 @@ class ReferenceScanner:
                 )
             )
 
-        findings.extend(self.missing_alts)
+        findings.extend(self.suspicious_domains)
 
         return IntegrityReport(
             file_path=self.file_path,
@@ -1266,6 +1174,7 @@ def _build_rule_engine(config: ZenzicConfig) -> AdaptiveRuleEngine | None:
         CredentialScannerRule,
         CustomRule,
         EmptyLinkRule,
+        MissingAltTextRule,
         MalformedFrontmatterRule,
         PluginRegistry,
         UntaggedCodeBlockRule,
@@ -1275,6 +1184,7 @@ def _build_rule_engine(config: ZenzicConfig) -> AdaptiveRuleEngine | None:
     built_in: list[BaseRule] = [
         CredentialScannerRule(),
         EmptyLinkRule(),
+        MissingAltTextRule(),
         CircularAnchorRule(),
         MalformedFrontmatterRule(),
         UntaggedCodeBlockRule(),

--- a/src/zenzic/core/validator.py
+++ b/src/zenzic/core/validator.py
@@ -1971,10 +1971,11 @@ def validate_links_structured(
 
 # ─── Decoupled URP for Language Server (In-Memory) ────────────────────────────
 
+
 def validate_single_document_urp(
     content: str,
     file_path: Path,
-    vsm: dict,
+    vsm: dict[str, Any],
     config: ZenzicConfig | None = None,
 ) -> list[LinkError]:
     """Decoupled URP entry point for single-file, in-memory validation.
@@ -1985,13 +1986,15 @@ def validate_single_document_urp(
     applicable.
     """
     from zenzic.core.rules import _extract_inline_links_with_lines
+
     config = config or ZenzicConfig()
     internal_errors: list[LinkError] = []
-    
+
     label = file_path.name
-    
+
     # Pre-split lines for source context
     lines = content.splitlines()
+
     def _source_line(lineno: int) -> str:
         idx = lineno - 1
         return lines[idx].strip() if 0 <= idx < len(lines) else ""
@@ -2000,7 +2003,7 @@ def validate_single_document_urp(
     _poly_html_urls = set()
     for node in _POLYGLOT_EXTRACTOR.extract(content):
         _source_ctx = _source_line(node.line_no)
-        
+
         if node.z205_scheme:
             internal_errors.append(
                 LinkError(
@@ -2014,7 +2017,7 @@ def validate_single_document_urp(
                 )
             )
             continue
-            
+
         for attr in node.blacklisted_attrs:
             internal_errors.append(
                 LinkError(
@@ -2082,7 +2085,7 @@ def validate_single_document_urp(
                 )
             )
             continue
-            
+
         if node.href:
             _poly_html_urls.add(node.href)
 
@@ -2091,15 +2094,17 @@ def validate_single_document_urp(
     _bypass_schemes = ("mailto", "tel", "javascript", "data", "irc", "xmpp")
     _effective_skip = tuple("http://") + tuple("https://") + tuple(f"{s}:" for s in _bypass_schemes)
 
-    for url, lineno, raw_line in _extract_inline_links_with_lines(content):
+    for url, lineno, _raw_line in _extract_inline_links_with_lines(content):
         if url.startswith(_effective_skip) or url == "#":
             continue
 
         parsed = urlsplit(url)
-        
+
         # Absolute path prohibition (Z105)
         if parsed.path.startswith("/") and parsed.scheme not in _bypass_schemes:
-            is_allowed = any(parsed.path.startswith(prefix) for prefix in config.absolute_path_allowlist)
+            is_allowed = any(
+                parsed.path.startswith(prefix) for prefix in config.absolute_path_allowlist
+            )
             if not is_allowed:
                 internal_errors.append(
                     LinkError(

--- a/src/zenzic/core/validator.py
+++ b/src/zenzic/core/validator.py
@@ -1969,6 +1969,170 @@ def validate_links_structured(
     return result  # type: ignore[return-value]
 
 
+# ─── Decoupled URP for Language Server (In-Memory) ────────────────────────────
+
+def validate_single_document_urp(
+    content: str,
+    file_path: Path,
+    vsm: dict,
+    config: ZenzicConfig | None = None,
+) -> list[LinkError]:
+    """Decoupled URP entry point for single-file, in-memory validation.
+
+    Runs the Uniform Resolver Pipeline (URP) checks—including PolyglotExtractor
+    (Z120-Z124, Z205), same-page anchors (Z102), and absolute path prohibitions
+    (Z105)—without any disk I/O, leveraging the pre-built VSM for context where
+    applicable.
+    """
+    from zenzic.core.rules import _extract_inline_links_with_lines
+    config = config or ZenzicConfig()
+    internal_errors: list[LinkError] = []
+    
+    label = file_path.name
+    
+    # Pre-split lines for source context
+    lines = content.splitlines()
+    def _source_line(lineno: int) -> str:
+        idx = lineno - 1
+        return lines[idx].strip() if 0 <= idx < len(lines) else ""
+
+    # Phase 1: Polyglot Extractor (HTML Links & Integrity)
+    _poly_html_urls = set()
+    for node in _POLYGLOT_EXTRACTOR.extract(content):
+        _source_ctx = _source_line(node.line_no)
+        
+        if node.z205_scheme:
+            internal_errors.append(
+                LinkError(
+                    file_path=file_path,
+                    line_no=node.line_no,
+                    message=f"{label}:{node.line_no}: forbidden scheme '{node.z205_scheme}' detected in <{node.tag}> {'href' if node.tag == 'a' else 'src'} — potential XSS vector (non-suppressible).",
+                    source_line=_source_ctx,
+                    error_type="Z205",
+                    col_start=0,
+                    match_text=node.raw_tag,
+                )
+            )
+            continue
+            
+        for attr in node.blacklisted_attrs:
+            internal_errors.append(
+                LinkError(
+                    file_path=file_path,
+                    line_no=node.line_no,
+                    message=f"{label}:{node.line_no}: opaque attribute '{attr}' detected in <{node.tag}> tag — event-handler or shadow-routing.",
+                    source_line=_source_ctx,
+                    error_type="Z124",
+                    col_start=0,
+                    match_text=node.raw_tag,
+                )
+            )
+
+        for attr in node.unknown_attrs:
+            internal_errors.append(
+                LinkError(
+                    file_path=file_path,
+                    line_no=node.line_no,
+                    message=f"{label}:{node.line_no}: unknown attribute '{attr}' in <{node.tag}> — not in Safe-Core list. Add to safe list or suppress with data-zenzic-ignore.",
+                    source_line=_source_ctx,
+                    error_type="Z120",
+                    col_start=0,
+                    match_text=node.raw_tag,
+                )
+            )
+
+        if node.is_missing_href:
+            internal_errors.append(
+                LinkError(
+                    file_path=file_path,
+                    line_no=node.line_no,
+                    message=f"{label}:{node.line_no}: <{node.tag}> has no {'href' if node.tag == 'a' else 'src'} attribute, or it is empty.",
+                    source_line=_source_ctx,
+                    error_type="Z121",
+                    col_start=0,
+                    match_text=node.raw_tag,
+                )
+            )
+            continue
+
+        if node.is_jump_link:
+            internal_errors.append(
+                LinkError(
+                    file_path=file_path,
+                    line_no=node.line_no,
+                    message=f'{label}:{node.line_no}: href="#" detected — placeholder or opaque JS anchor. Add a real destination or suppress with data-zenzic-ignore.',
+                    source_line=_source_ctx,
+                    error_type="Z122",
+                    col_start=0,
+                    match_text=node.raw_tag,
+                )
+            )
+            continue
+
+        if node.info_scheme:
+            internal_errors.append(
+                LinkError(
+                    file_path=file_path,
+                    line_no=node.line_no,
+                    message=f"{label}:{node.line_no}: non-HTTP scheme '{node.info_scheme}' in <{node.tag}> — link not resolved by Zenzic (informational).",
+                    source_line=_source_ctx,
+                    error_type="Z123",
+                    col_start=0,
+                    match_text=node.raw_tag,
+                )
+            )
+            continue
+            
+        if node.href:
+            _poly_html_urls.add(node.href)
+
+    # Phase 2: Markdown Links and Same-Page Anchors
+    local_anchors = anchors_in_file(content)
+    _bypass_schemes = ("mailto", "tel", "javascript", "data", "irc", "xmpp")
+    _effective_skip = tuple("http://") + tuple("https://") + tuple(f"{s}:" for s in _bypass_schemes)
+
+    for url, lineno, raw_line in _extract_inline_links_with_lines(content):
+        if url.startswith(_effective_skip) or url == "#":
+            continue
+
+        parsed = urlsplit(url)
+        
+        # Absolute path prohibition (Z105)
+        if parsed.path.startswith("/") and parsed.scheme not in _bypass_schemes:
+            is_allowed = any(parsed.path.startswith(prefix) for prefix in config.absolute_path_allowlist)
+            if not is_allowed:
+                internal_errors.append(
+                    LinkError(
+                        file_path=file_path,
+                        line_no=lineno,
+                        message=f"{label}:{lineno}: '{url}' uses an absolute path — use a relative path (e.g. '../' or './') instead; absolute paths break portability when the site is hosted in a subdirectory",
+                        source_line=_source_line(lineno),
+                        error_type="Z105",
+                        col_start=0,
+                        match_text=url,
+                    )
+                )
+            continue
+
+        # Same-page anchors (Z102)
+        if not parsed.path and parsed.fragment:
+            anchor = parsed.fragment.lower()
+            if anchor not in local_anchors:
+                internal_errors.append(
+                    LinkError(
+                        file_path=file_path,
+                        line_no=lineno,
+                        message=f"{label}:{lineno}: anchor '#{anchor}' not found in '{label}'",
+                        source_line=_source_line(lineno),
+                        error_type="Z102",
+                        col_start=0,
+                        match_text=url,
+                    )
+                )
+
+    return internal_errors
+
+
 # ─── Multi-language snippet validation ────────────────────────────────────────
 
 _VALIDATABLE_LANGS = frozenset({"python", "py", "yaml", "yml", "json", "toml"})

--- a/src/zenzic/lsp/server.py
+++ b/src/zenzic/lsp/server.py
@@ -16,7 +16,7 @@ from typing import Any, BinaryIO, TypedDict, cast
 from zenzic.core.adapters import get_adapter
 from zenzic.core.discovery import iter_markdown_sources
 from zenzic.core.exclusion import LayeredExclusionManager
-from zenzic.core.rules import AdaptiveRuleEngine, ResolutionContext
+from zenzic.core.rules import AdaptiveRuleEngine, ResolutionContext, RuleFinding
 from zenzic.core.scanner import _build_rule_engine
 from zenzic.lsp.documents import DocumentManager
 from zenzic.models.config import ZenzicConfig
@@ -319,7 +319,15 @@ class LanguageServer:
             self.documents.did_close(params)
 
     def _publish_diagnostics(self, uri: str, text: str) -> None:
-        """Run the rule engine on the in-memory document state and publish diagnostics."""
+        """Run the rule engine on the in-memory document state and publish diagnostics.
+
+        Diagnostic sources (all pure / zero disk-I/O for the current document):
+
+        1. ``rule_engine.run()``  — built-in rules: Z108, Z201, Z505, Z107, Z506, Z601 …
+        2. ``rule_engine.run_vsm()`` — VSM-aware rules: Z101 (broken cross-file link)
+        3. ``validate_single_document_urp()`` — Decoupled URP: PolyglotExtractor (Z120-124, Z205), same-page anchors (Z102), absolute paths (Z105)
+        4. ``check_snippet_content()`` — Z503: malformed code snippets
+        """
 
         if uri.startswith("file://"):
             file_path = Path(uri[7:])
@@ -332,9 +340,10 @@ class LanguageServer:
         if not self.rule_engine:
             self.rule_engine = _build_rule_engine(self.config)
 
-        # O(N) parsing across the text
+        # ── 1. Core rule engine (Z108, Z201, Z505, Z107, Z506, …) ─────────────
         findings = self.rule_engine.run(file_path, text) if self.rule_engine else []
 
+        # ── 2. VSM-aware rules (Z101 — broken cross-file link) ────────────────
         if self.vsm is not None and self.config is not None and self.repo_root is not None:
             assert self.rule_engine is not None
             docs_root = self.repo_root / self.config.docs_dir
@@ -344,7 +353,31 @@ class LanguageServer:
             )
             findings.extend(vsm_findings)
 
-        # Snippet syntax validation (Z503)
+        # ── 3. URP (Uniform Resolver Pipeline) - In-Memory Validation (Z102, Z120-Z124, Z205, Z105)
+        from zenzic.core.validator import validate_single_document_urp
+        
+        urp_errors = validate_single_document_urp(
+            content=text,
+            file_path=file_path,
+            vsm=self.vsm or {},
+            config=self.config
+        )
+        
+        for err in urp_errors:
+            findings.append(
+                RuleFinding(
+                    file_path=err.file_path,
+                    line_no=err.line_no,
+                    rule_id=err.error_type,
+                    message=err.message,
+                    severity="error" if err.error_type != "Z123" else "info",
+                    matched_line=err.source_line,
+                    col_start=err.col_start,
+                    match_text=err.match_text,
+                )
+            )
+
+        # ── 5. Snippet syntax validation (Z503) ───────────────────────────────
         from zenzic.core.validator import check_snippet_content
 
         snippet_errors = check_snippet_content(text, file_path, ZenzicConfig())

--- a/src/zenzic/lsp/server.py
+++ b/src/zenzic/lsp/server.py
@@ -355,14 +355,11 @@ class LanguageServer:
 
         # ── 3. URP (Uniform Resolver Pipeline) - In-Memory Validation (Z102, Z120-Z124, Z205, Z105)
         from zenzic.core.validator import validate_single_document_urp
-        
+
         urp_errors = validate_single_document_urp(
-            content=text,
-            file_path=file_path,
-            vsm=self.vsm or {},
-            config=self.config
+            content=text, file_path=file_path, vsm=self.vsm or {}, config=self.config
         )
-        
+
         for err in urp_errors:
             findings.append(
                 RuleFinding(

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -453,3 +453,119 @@ def test_vsm_integration_and_dynamic_watching(tmp_path) -> None:
 
     finally:
         os.chdir(old_cwd)
+
+
+# ─── CLI/ZLS Parity tests: Z403 and Z102 ─────────────────────────────────────
+
+
+def _collect_diagnostics(text: str, uri: str = "file:///fake/path/doc.md") -> list[dict]:
+    """Run the ZLS on a single document and return all emitted diagnostics."""
+    import io
+    import json
+
+    def encode_rpc(msg: dict) -> bytes:
+        body = json.dumps(msg, separators=(",", ":")).encode("utf-8")
+        header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+        return header + body
+
+    in_stream = io.BytesIO()
+    in_stream.write(
+        encode_rpc(
+            {
+                "jsonrpc": "2.0",
+                "method": "textDocument/didOpen",
+                "params": {"textDocument": {"uri": uri, "text": text}},
+            }
+        )
+    )
+    in_stream.write(encode_rpc({"jsonrpc": "2.0", "method": "exit", "params": {}}))
+    in_stream.seek(0)
+
+    out_stream = io.BytesIO()
+    server = LanguageServer(stdin=in_stream, stdout=out_stream)
+    server.serve()
+
+    out_stream.seek(0)
+    output = out_stream.read()
+
+    all_diagnostics: list[dict] = []
+    for part in output.split(b"\r\n\r\n"):
+        if b"publishDiagnostics" not in part:
+            continue
+        body_str = part.split(b"Content-Length")[0]
+        try:
+            resp = json.loads(body_str.decode("utf-8"))
+            if resp.get("method") == "textDocument/publishDiagnostics":
+                all_diagnostics.extend(resp["params"]["diagnostics"])
+        except json.JSONDecodeError:
+            pass
+    return all_diagnostics
+
+
+def test_lsp_emits_z403() -> None:
+    """ZLS must report Z403 for inline images and HTML <img> tags missing alt text.
+
+    Parity target: ``zenzic check all --strict`` emits Z403 for both syntaxes.
+    The ZLS must match this output without requiring a VSM (zero-config mode).
+    """
+    doc = (
+        "# Image Alt Text Test\n"
+        "\n"
+        "Inline image without alt text:\n"
+        "![](https://example.com/image.png)\n"
+        "\n"
+        "HTML img without alt text:\n"
+        '<img src="https://example.com/image.png">\n'
+    )
+    diagnostics = _collect_diagnostics(doc)
+
+    z403_codes = [d for d in diagnostics if d.get("code") == "Z403"]
+    assert len(z403_codes) == 2, (
+        f"Expected 2 Z403 diagnostics (inline + HTML <img>), got {len(z403_codes)}. "
+        f"All diagnostics: {[d['code'] for d in diagnostics]}"
+    )
+
+    # Inline image is on line 4 (0-indexed: line 3)
+    inline_diag = next(
+        (d for d in z403_codes if d["range"]["start"]["line"] == 3), None
+    )
+    assert inline_diag is not None, "Z403 should be reported on line 4 (the inline image)"
+
+    # HTML <img> is on line 7 (0-indexed: line 6)
+    html_diag = next(
+        (d for d in z403_codes if d["range"]["start"]["line"] == 6), None
+    )
+    assert html_diag is not None, "Z403 should be reported on line 7 (the HTML img)"
+
+
+def test_lsp_emits_z102() -> None:
+    """ZLS must report Z102 for fragment links to anchors absent in the same document.
+
+    Parity target: ``zenzic check all --strict`` emits Z102 for
+    ``[Link to missing anchor](#this-anchor-does-not-exist)``.
+    The ZLS must match this output without requiring a VSM (zero-config mode).
+    """
+    doc = (
+        "# Real Heading\n"
+        "\n"
+        "## Z102 - Missing Anchor\n"
+        "[Link to missing anchor](#this-anchor-does-not-exist)\n"
+        "\n"
+        "[Valid link](#real-heading)\n"
+    )
+    diagnostics = _collect_diagnostics(doc)
+
+    z102_codes = [d for d in diagnostics if d.get("code") == "Z102"]
+    assert len(z102_codes) == 1, (
+        f"Expected exactly 1 Z102 diagnostic (broken anchor), got {len(z102_codes)}. "
+        f"All diagnostics: {[d['code'] for d in diagnostics]}"
+    )
+
+    broken_diag = z102_codes[0]
+    # The broken link is on line 4 (0-indexed: line 3)
+    assert broken_diag["range"]["start"]["line"] == 3, (
+        f"Z102 should be on line 4, got line {broken_diag['range']['start']['line'] + 1}"
+    )
+    assert "this-anchor-does-not-exist" in broken_diag["message"], (
+        f"Z102 message should mention the missing fragment, got: {broken_diag['message']}"
+    )

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -526,15 +526,11 @@ def test_lsp_emits_z403() -> None:
     )
 
     # Inline image is on line 4 (0-indexed: line 3)
-    inline_diag = next(
-        (d for d in z403_codes if d["range"]["start"]["line"] == 3), None
-    )
+    inline_diag = next((d for d in z403_codes if d["range"]["start"]["line"] == 3), None)
     assert inline_diag is not None, "Z403 should be reported on line 4 (the inline image)"
 
     # HTML <img> is on line 7 (0-indexed: line 6)
-    html_diag = next(
-        (d for d in z403_codes if d["range"]["start"]["line"] == 6), None
-    )
+    html_diag = next((d for d in z403_codes if d["range"]["start"]["line"] == 6), None)
     assert html_diag is not None, "Z403 should be reported on line 7 (the HTML img)"
 
 

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -17,7 +17,7 @@ Credential Scanner (core/credentials.py):
   - No false positives on clean URLs
 
 ReferenceScanner (core/scanner.py):
-  - Pass 1 (harvest): DEF, DUPLICATE_DEF, IMG, MISSING_ALT, SECRET events
+  - Pass 1 (harvest): DEF, DUPLICATE_DEF, SECRET events
   - Pass 2 (cross_check): DANGLING detection
   - Pass 3 (get_integrity_report): DEAD_DEF, duplicate-def, score
   - "Phantom Reference Trap": [text][id] with no definition → DANGLING
@@ -25,7 +25,7 @@ ReferenceScanner (core/scanner.py):
   - Credential scanner acting as firewall: Pass 2 skipped when secrets found
   - Alt-text check: pure function and via harvest events
 
-check_image_alt_text (core/scanner.py):
+MissingAltTextRule (core/rules.py):
   - Inline Markdown images
   - HTML <img> tags
   - Empty alt attribute not flagged (intentionally decorative)
@@ -44,7 +44,6 @@ from _helpers import make_mgr
 from zenzic.core.credentials import SecurityFinding, scan_line_for_secrets, scan_url_for_secrets
 from zenzic.core.scanner import (
     ReferenceScanner,
-    check_image_alt_text,
     scan_docs_references,
 )
 from zenzic.core.validator import LinkValidator
@@ -269,46 +268,67 @@ class TestCredentialScanner:
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# check_image_alt_text (pure function)
+# MissingAltTextRule (Z403)
 # ══════════════════════════════════════════════════════════════════════════════
 
 
-class TestCheckImageAltText:
+class TestMissingAltTextRule:
     def test_no_images_no_findings(self) -> None:
+        from zenzic.core.rules import MissingAltTextRule
+
         text = "# Title\n\nSome prose without any images.\n"
-        assert check_image_alt_text(text, Path("doc.md")) == []
+        rule = MissingAltTextRule()
+        assert rule.check(Path("doc.md"), text) == []
 
     def test_image_with_alt_text_ok(self) -> None:
+        from zenzic.core.rules import MissingAltTextRule
+
         text = "![A diagram showing the pipeline](pipeline.png)\n"
-        assert check_image_alt_text(text, Path("doc.md")) == []
+        rule = MissingAltTextRule()
+        assert rule.check(Path("doc.md"), text) == []
 
     def test_image_without_alt_text_flagged(self) -> None:
+        from zenzic.core.rules import MissingAltTextRule
+
         text = "![](pipeline.png)\n"
-        findings = check_image_alt_text(text, Path("doc.md"))
+        rule = MissingAltTextRule()
+        findings = rule.check(Path("doc.md"), text)
         assert len(findings) == 1
-        assert findings[0].issue == "Z403"
-        assert findings[0].is_warning is True
+        assert findings[0].rule_id == "Z403"
+        assert findings[0].severity == "warning"
         assert findings[0].line_no == 1
 
     def test_image_whitespace_only_alt_flagged(self) -> None:
+        from zenzic.core.rules import MissingAltTextRule
+
         text = "![   ](pipeline.png)\n"
-        findings = check_image_alt_text(text, Path("doc.md"))
+        rule = MissingAltTextRule()
+        findings = rule.check(Path("doc.md"), text)
         assert len(findings) == 1
 
     def test_html_img_without_alt_flagged(self) -> None:
+        from zenzic.core.rules import MissingAltTextRule
+
         text = '<img src="diagram.png">\n'
-        findings = check_image_alt_text(text, Path("doc.md"))
+        rule = MissingAltTextRule()
+        findings = rule.check(Path("doc.md"), text)
         assert len(findings) == 1
-        assert findings[0].issue == "Z403"
+        assert findings[0].rule_id == "Z403"
 
     def test_html_img_with_alt_ok(self) -> None:
+        from zenzic.core.rules import MissingAltTextRule
+
         text = '<img src="diagram.png" alt="A flowchart">\n'
-        findings = check_image_alt_text(text, Path("doc.md"))
+        rule = MissingAltTextRule()
+        findings = rule.check(Path("doc.md"), text)
         assert findings == []
 
     def test_mixed_images_multiple_findings(self) -> None:
+        from zenzic.core.rules import MissingAltTextRule
+
         text = '![Good alt](a.png)\n![](b.png)\n![also good](c.png)\n<img src="d.png">\n'
-        findings = check_image_alt_text(text, Path("doc.md"))
+        rule = MissingAltTextRule()
+        findings = rule.check(Path("doc.md"), text)
         assert len(findings) == 2
         line_nos = {f.line_no for f in findings}
         assert line_nos == {2, 4}
@@ -345,21 +365,6 @@ class TestReferenceScannerHarvest:
         assert types.count("DUPLICATE_DEF") == 1
         # First wins
         assert scanner.ref_map.resolve("ref") == "https://first.com"
-
-    def test_harvest_missing_alt_event(self, tmp_path: Path) -> None:
-        md = self._write_md(tmp_path, "![](diagram.png)\n")
-        scanner = ReferenceScanner(md)
-        events = list(scanner.harvest())
-        types = [e[1] for e in events]
-        assert "MISSING_ALT" in types
-
-    def test_harvest_img_event_with_alt(self, tmp_path: Path) -> None:
-        md = self._write_md(tmp_path, "![A diagram](diagram.png)\n")
-        scanner = ReferenceScanner(md)
-        events = list(scanner.harvest())
-        types = [e[1] for e in events]
-        assert "IMG" in types
-        assert "MISSING_ALT" not in types
 
     def test_harvest_secret_in_definition_url(self, tmp_path: Path) -> None:
         """A reference definition whose URL contains an OpenAI key → SECRET event."""

--- a/uv.lock
+++ b/uv.lock
@@ -2465,7 +2465,7 @@ wheels = [
 
 [[package]]
 name = "zenzic"
-version = "0.22.1"
+version = "0.22.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-re2" },


### PR DESCRIPTION
## Overview
This pull request completely decouples the Uniform Resolver Pipeline (URP) to support pure in-memory document validation, ensuring 100% diagnostic parity between the CLI (`zenzic check`) and the VS Code Language Server. 
## Key Changes
- **Decoupled Pipeline:** Introduced `validate_single_document_urp()` to run HTML integrity checks (Z120-Z124, Z205), same-page anchors (Z102), and absolute paths (Z105) without redundant disk I/O.
- **Single Source of Truth:** `server.py` is stripped of hardcoded validation rules and now acts strictly as a transport layer.
- **Rule Unification:** Refactored `Z403` (Missing Alt Text) into a native `BaseRule`, guaranteeing consistent behavior across both execution paths.
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (architecture improvements)
