### PR TITLE
chore(release): bump version to 0.23.1

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tool.bumpversion]
-current_version = "0.23.0"
+current_version = "0.23.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}{pre_l}{pre_n}",

--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Zenzic version
       description: Output of `zenzic --version`
-      placeholder: "0.23.0"
+      placeholder: "0.23.1"
     validations:
       required: true
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 #
 #   repos:
 #     - repo: https://github.com/PythonWoods/zenzic
-#       rev: v0.23.0
+#       rev: v0.23.1
 #       hooks:
 #         - id: zenzic-verify    # quality gate — corrisponde a `just verify` lato zenzic
 #         - id: zenzic-guard     # fast staged-file credential scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.23.1] - 2026-07-22
+
+### Added
+
+- **LSP Diagnostic Payload Formatting (`ZenzicDiagnostic.to_lsp_dict()`)**: Added `codeDescription` property with `href` pointing to `https://zenzic.dev/docs/reference/finding-codes#{code}` and prepended `[{code}] ` prefix to diagnostic messages per LSP 3.16/3.17 specifications (`ZLS-UX-001-DIAGNOSTIC-FORMATTING`).
+
 ## [0.23.0] - 2026-07-18
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ abstract: >-
   performs deterministic static analysis using a two-pass reference
   pipeline and a RE2-backed credential scanner, with zero subprocess
   calls and full SARIF 2.1.0 support for CI/CD integration.
-version: 0.23.0
-date-released: 2026-07-18
+version: 0.23.1
+date-released: 2026-07-22
 url: "https://zenzic.dev"
 repository-code: "https://github.com/PythonWoods/zenzic"
 repository-artifact: "https://pypi.org/project/zenzic/"

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Zenzic Core is headless and emits standardized **SARIF** (Static Analysis Result
       "tool": {
         "driver": {
           "name": "zenzic",
-          "version": "0.23.0",
+          "version": "0.23.1",
           "rules": [
             {
               "id": "Z101",
@@ -275,7 +275,7 @@ uv tool upgrade zenzic
 To run a specific version ephemerally without altering your global environment:
 
 ```bash
-uvx zenzic@0.23.0 check all
+uvx zenzic@0.23.1 check all
 ```
 
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,9 +8,9 @@
 
 | Field    | Value      |
 | :------- | :--------- |
-| Version  | v0.23.0     |
+| Version  | v0.23.1     |
 | Codename | Magnetite   |
-| Date     | 2026-07-18 |
+| Date     | 2026-07-22 |
 | Status   | Stable |
 
 ## Release Checklist
@@ -21,7 +21,7 @@ Before tagging, every item must be green:
 - [ ] `zenzic lab all` — all 20 scenarios exit with expected code
 - [ ] `zenzic score --stamp` committed — badge in README.md reflects current score
 - [ ] `zenzic check all .` — zero findings in the repo root
-- [ ] `pyproject.toml` version matches the tag (`0.23.0`)
+- [ ] `pyproject.toml` version matches the tag (`0.23.1`)
 - [ ] `CITATION.cff` version and date updated
 - [ ] `CHANGELOG.md` — `[Unreleased]` section moved to the new version heading
 - [ ] Update SECURITY.md support table (Add new release, demote previous to Critical/EOL).
@@ -53,11 +53,11 @@ git checkout main
 git pull origin main
 
 # 3. Tag the main branch and push
-git tag v0.23.0
+git tag v0.23.1
 git push origin main --tags
 ```
 
-- [ ] Create GitHub Release from the tag, using the `## [0.23.0]` CHANGELOG section as the release body.
+- [ ] Create GitHub Release from the tag, using the `## [0.23.1]` CHANGELOG section as the release body.
 
 ## Changelog Reference
 

--- a/docs/architecture/lsp-integration.md
+++ b/docs/architecture/lsp-integration.md
@@ -33,7 +33,12 @@ class ZenzicDiagnostic:
     message: str                # Human-readable description
 ```
 
-The `to_lsp_dict()` method is the **single serialization boundary**. Untyped dicts are never used for diagnostic payloads; `Any` is forbidden in the diagnostic model.
+The `to_lsp_dict()` method is the **single serialization boundary**. Untyped dicts are never used for diagnostic payloads; `Any` is forbidden in the diagnostic model. At the serialization boundary, `to_lsp_dict()` formats the diagnostic payload per LSP 3.16/3.17 specifications:
+
+- Prepends the Z-Code prefix to the emitted `message` string (`[{code}] {message}`).
+- Includes the `codeDescription` property with `href` pointing to `https://zenzic.dev/docs/reference/finding-codes#{code}`.
+
+Internal `ZenzicDiagnostic` instances retain unformatted, raw messages to preserve core engine independence.
 
 ## VirtualBufferOverlay
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -203,7 +203,7 @@ extra:
   # ADR-037: No hardcoded SemVer in any .html or .md source.
   # CI pipeline passes the current version at build time, e.g.:
   #   uv run mkdocs build --extra zenzic_version=0.14.1
-  zenzic_version: "0.23.0"  # release sync
+  zenzic_version: "0.23.1"  # release sync
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/PythonWoods/zenzic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zenzic"
-version = "0.23.0"
+version = "0.23.1"
 description = "Engineering-grade, engine-agnostic static analyzer and credential scanner for Markdown documentation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/zenzic/__init__.py
+++ b/src/zenzic/__init__.py
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """Zenzic — engine-agnostic static analyzer and credential scanner for Markdown documentation."""
 
-__version__ = "0.23.0"
+__version__ = "0.23.1"
 __version_name__ = "Basalt"  # Release codename stored separately from the package version.

--- a/src/zenzic/cli/_standalone.py
+++ b/src/zenzic/cli/_standalone.py
@@ -1588,7 +1588,7 @@ version = "0.1.0"
 description = "Custom Zenzic plugin rule package"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["zenzic>=0.23.0"]
+dependencies = ["zenzic>=0.23.1"]
 
 [project.entry-points."zenzic.rules"]
 {project_slug} = "{module_name}.rules:{class_name}"

--- a/src/zenzic/models/diagnostics.py
+++ b/src/zenzic/models/diagnostics.py
@@ -61,7 +61,9 @@ class ZenzicDiagnostic:
 
     # ── Serialization boundary ────────────────────────────────────────────────
 
-    def to_lsp_dict(self) -> dict[str, int | str | dict[str, dict[str, int]]]:
+    def to_lsp_dict(
+        self,
+    ) -> dict[str, int | str | dict[str, str] | dict[str, dict[str, int]]]:
         """Serialize to the exact shape required by LSP ``publishDiagnostics``.
 
         This is the ONLY location in the codebase where a ``ZenzicDiagnostic``
@@ -81,6 +83,9 @@ class ZenzicDiagnostic:
             },
             "severity": int(self.severity),
             "code": self.code,
+            "codeDescription": {
+                "href": f"https://zenzic.dev/docs/reference/finding-codes#{self.code}",
+            },
             "source": self.source,
-            "message": self.message,
+            "message": f"[{self.code}] {self.message}",
         }

--- a/tests/unit/test_diagnostics_formatting.py
+++ b/tests/unit/test_diagnostics_formatting.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev>
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ZenzicDiagnostic LSP payload serialization (ZLS-UX-001-DIAGNOSTIC-FORMATTING)."""
+
+from __future__ import annotations
+
+from zenzic.models.diagnostics import (
+    DiagnosticPosition,
+    DiagnosticRange,
+    Severity,
+    ZenzicDiagnostic,
+)
+
+
+def test_to_lsp_dict_formatting() -> None:
+    """Verify that to_lsp_dict prepends [Z-Code] to message and includes codeDescription href."""
+    diag = ZenzicDiagnostic(
+        range=DiagnosticRange(
+            start=DiagnosticPosition(line=0, character=0),
+            end=DiagnosticPosition(line=0, character=10),
+        ),
+        severity=Severity.ERROR,
+        code="Z101",
+        source="zenzic",
+        message="'missing.md' resolves to nowhere",
+    )
+
+    lsp_dict = diag.to_lsp_dict()
+
+    assert lsp_dict["code"] == "Z101"
+    assert lsp_dict["message"] == "[Z101] 'missing.md' resolves to nowhere"
+    assert lsp_dict["codeDescription"] == {
+        "href": "https://zenzic.dev/docs/reference/finding-codes#Z101",
+    }
+    assert lsp_dict["source"] == "zenzic"
+    assert lsp_dict["severity"] == 1
+    assert lsp_dict["range"] == {
+        "start": {"line": 0, "character": 0},
+        "end": {"line": 0, "character": 10},
+    }
+
+
+def test_internal_message_immutability() -> None:
+    """Verify that calling to_lsp_dict does not alter the internal dataclass message attribute."""
+    original_message = "Broken link target: /nonexistent.md"
+    diag = ZenzicDiagnostic(
+        range=DiagnosticRange(
+            start=DiagnosticPosition(line=5, character=2),
+            end=DiagnosticPosition(line=5, character=20),
+        ),
+        severity=Severity.WARNING,
+        code="Z203",
+        source="zenzic",
+        message=original_message,
+    )
+
+    # Invoke serialization
+    lsp_dict = diag.to_lsp_dict()
+
+    # Core internal dataclass message attribute must remain unchanged
+    assert diag.message == original_message
+    assert diag.message != lsp_dict["message"]
+    assert lsp_dict["message"] == f"[Z203] {original_message}"
+
+
+def test_to_lsp_dict_keys_schema() -> None:
+    """Verify exact JSON keys generated in to_lsp_dict for LSP 3.16/3.17 compliance."""
+    diag = ZenzicDiagnostic(
+        range=DiagnosticRange(
+            start=DiagnosticPosition(line=1, character=1),
+            end=DiagnosticPosition(line=1, character=5),
+        ),
+        severity=Severity.HINT,
+        code="Z501",
+        source="zenzic",
+        message="Style suggestion",
+    )
+
+    lsp_dict = diag.to_lsp_dict()
+    expected_keys = {"range", "severity", "code", "codeDescription", "source", "message"}
+    assert set(lsp_dict.keys()) == expected_keys


### PR DESCRIPTION
## Summary

This PR cuts the patch release **v0.23.1** for Zenzic Core, incorporating LSP diagnostic payload formatting enhancements (`ZLS-UX-001-DIAGNOSTIC-FORMATTING`).

## Key Changes

- **LSP Diagnostic Payload Formatting (`ZenzicDiagnostic.to_lsp_dict()`)**:
  - Added `codeDescription` property with `href` pointing to `https://zenzic.dev/docs/reference/finding-codes#{code}` per LSP 3.16/3.17.
  - Prepended `[{code}] ` prefix to diagnostic `message` strings at the JSON-RPC serialization boundary.
  - Retained pristine, un-prefixed messages in internal `ZenzicDiagnostic` instances.
- **Documentation Parity (ADR-020)**: Updated `docs/architecture/lsp-integration.md`.
- **Unit Test Suite**: Added `tests/unit/test_diagnostics_formatting.py` covering serialization schema and immutability.
- **Version Manifests**: Bumped version to `0.23.1` across `pyproject.toml`, `src/zenzic/__init__.py`, `mkdocs.yml`, `README.md`, `CITATION.cff`, and `RELEASE.md`.
