### PR TITLE
docs(align): position Zenzic as Deterministic Document Integrity Engine and SAST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **LSP Diagnostic Payload Formatting (`ZenzicDiagnostic.to_lsp_dict()`)**: Added `codeDescription` property with `href` pointing to `https://zenzic.dev/docs/reference/finding-codes#{code}` and prepended `[{code}] ` prefix to diagnostic messages per LSP 3.16/3.17 specifications (`ZLS-UX-001-DIAGNOSTIC-FORMATTING`).
+- **LSP Diagnostic Payload Formatting (`ZenzicDiagnostic.to_lsp_dict()`)**: Added `codeDescription` property with `href` pointing to `https://zenzic.dev/docs/reference/finding-codes#{code}` and prepended `[{code}]` prefix to diagnostic messages per LSP 3.16/3.17 specifications (`ZLS-UX-001-DIAGNOSTIC-FORMATTING`).
 
 ## [0.23.0] - 2026-07-18
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,8 @@
 
 Thank you for your interest in contributing to Zenzic!
 
-Zenzic is a documentation quality tool — an engine-agnostic linter and credential scanner
-for Markdown and MDX documentation. Contributions that improve detection accuracy, add
-new check types, or improve CI/CD integration are especially welcome.
+Zenzic is a Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs.
+We welcome contributions that improve reliability, performance, adapter accuracy, or usability.
 
 ## Two Repositories, Two Doors
 
@@ -26,10 +25,8 @@ head to [zenzic-doc](https://github.com/PythonWoods/zenzic).
 
 ## Mission
 
-Zenzic is not just a linter. It is a long-term safety layer for documentation teams that
-depend on open, auditable source files. We preserve validation continuity across engine
-changes (MkDocs, Docusaurus, Zensical, and future adapters) so projects keep control over
-their data and quality process regardless of ecosystem churn.
+Zenzic is a long-term safety layer for documentation teams that
+rely on deterministic outputs. All contributions must respect the foundational principles:
 
 ## Contributor Contract
 
@@ -280,7 +277,7 @@ To ensure consistency between the core engine (**zenzic**) and the documentation
 
 ### 🔍 How it works
 
-1. **Local Development**: The linter always looks for the core repository in the adjacent folder (`../zenzic`). You are responsible for keeping local branches aligned.
+1. **Local Development**: The action always looks for the core repository in the adjacent folder (`../zenzic`). You are responsible for keeping local branches aligned.
 2. **In CI (GitHub Actions)**: The documentation pipeline attempts to clone the core repository by looking for a branch with the **exact same name** as the one being built in the doc repo.
 3. **Fallback**: If the mirrored branch is not found in the core repo, the CI will automatically fall back to the `main` branch.
 
@@ -306,7 +303,7 @@ maintainer (or an attacker who compromises one) can move a tag silently,
 poisoning the local Gate 2 without any diff in this repository.
 
 This is an **internal CI policy for the Zenzic project**, not a public Zenzic
-linter rule: it constrains how *we* develop Zenzic, not how Zenzic users
+rule: it constrains how *we* develop Zenzic, not how Zenzic users
 develop their own documentation. The orchestrator-level enforcement lives in
 `just check-pinning` (dependency of `just verify`); violations raise
 `[ADR-089] FATAL` at pre-push.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ SPDX-License-Identifier: Apache-2.0
 </p>
 
 <p align="center">
-  <strong>Deterministic audit of documentation structures with bidirectional traceability.</strong><br>
+  <strong>Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs.</strong><br>
   <em>Tiered code governance, frozen security contracts, and RE2-backed deterministic scanning.</em>
 </p>
 
@@ -47,15 +47,15 @@ SPDX-License-Identifier: Apache-2.0
 
 ## ⚡ Try it now — Zero Installation
 
-Got a folder of Markdown files? Run an instant security and link audit using [`uv`][uv]:
+Analyzing documentation graphs? Run instant security and topological analysis using [`uv`][uv]:
 
 ```bash
 uvx zenzic check all ./your-folder
 ```
 
 Zenzic identifies your engine via its configuration files or defaults to **Standalone Mode**
-for plain Markdown folders — providing immediate protection for links, credentials, and
-file integrity.
+when analyzing documentation graphs — providing immediate SAST protection for links, credentials, and
+graph integrity.
 
 ---
 
@@ -65,15 +65,28 @@ file integrity.
 pip install zenzic
 cd my-docs-repo
 zenzic init       # Establish the workspace boundary (creates .zenzic.toml)
-zenzic check all  # Audit the current directory
+zenzic check all  # Analyze documentation graphs in current directory
 ```
 
-## 🧠 Core Pillars
+## 🧠 Key Capabilities
 
-- **Pure, deterministic engine:** identical inputs produce identical findings and exits.
-- **Tiered code model:** Core, Structure, and Governance findings grouped by tier.
-- **Frozen contracts for integrators:** `FROZEN_CODES`, `NON_SUPPRESSIBLE_CODES`, and `PLUGIN_FORBIDDEN_EXITS` provide stable enforcement surfaces for CI and plugins.
-- **Inspect-first workflow:** use `zenzic inspect codes` to validate live code semantics before touching docs or release notes.
+### 1. Security Scanning (SAST)
+
+- **Z2xx Rules**: Hardened Static Application Security Testing for documentation graphs.
+- **Credential Leaks (Z201)**: Hardcoded tokens, API keys, and secret patterns detected before reaching PRs.
+- **Path Traversal Guard (Z202 / Z203)**: Non-suppressible filesystem boundary security checks; fatal exit codes (exits 2/3) survive `fail-on-error: false`.
+
+### 2. Graph Topology Analysis
+
+- **Virtual Site Map (VSM)**: Comprehensive $O(N)$ topological modeling of documentation graphs.
+- **Cross-File Link Resolution**: Validates anchor boundaries and cross-document dependencies.
+- **Orphan Pages & Dead Navigation**: Flags unlinked graph nodes, missing directory indices, and unreachable content.
+
+### 3. Deterministic CI/CD Enforcement
+
+- **Zero-DBT Quality Gate**: Bit-for-bit identical findings across all execution environments.
+- **Frozen Contracts**: `FROZEN_CODES`, `NON_SUPPRESSIBLE_CODES`, and standardized SARIF output.
+- **Inspect-First Workflow**: Query live code semantics with `zenzic inspect codes`.
 
 📖 [Full docs →][docs-home] · 🏅 [Badges][docs-badges] · 🔄 [CI/CD guide][docs-cicd]
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,85 +7,79 @@ SPDX-License-Identifier: Apache-2.0
 
 > **Governance Note (ADR-020):** This document is a root governance file. It is strictly **English-Only**. It must not be translated or mirrored in the `i18n/` directory.
 
-This document describes the planned milestone trajectory for Zenzic.
+This document describes the planned milestone trajectory for Zenzic, the **Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs**.
 Dates are targets, not commitments. All milestones are subject to revision.
 
-For the current release history, see [CHANGELOG.md](CHANGELOG.md).
+For the current release history and completed milestones (up to `v0.23.x`), see [CHANGELOG.md](CHANGELOG.md).
 
 ---
 
-## Recent Releases
+## Immediate Infrastructural Priorities
 
-### [v0.18.0] - Zenzic Routing Kernel (Completed)
+Before advancing the core feature set, the following infrastructural and validation tasks are prioritized:
 
-- **Zenzic Deterministic Routing Kernel**: Disjoint Domain Model utilizing explicit static mapping for loop-free, 100% deterministic edge resolution (Nuclear Static v12).
-
----
-
-### [v0.19.0] - The AST Foundations (Completed)
-
-*Lossless AST Parser, O(N) Inline Tokenization, Mutator Engine, Atomic File Writer, Z108 Auto-Fix.*
+- **Empirical Benchmark Suite:** Audit large-scale open-source repositories (e.g., Kubernetes, Docusaurus) to empirically prove $O(N)$ complexity, sub-50ms latency, and SAST capabilities against real-world documentation graphs.
+- **OIDC/Entra ID CI/CD Integration:** Resolve VS Code Marketplace publishing technical debt by transitioning from legacy Personal Access Tokens (PAT) to Workload Identity Federation before the December 2026 deprecation deadline.
 
 ---
 
-### [v0.20.0] - The Extensibility Update (Completed)
+## Milestone Sequence
 
-*Custom Rules API v2, deterministic visitation sandbox, auto-fix expansion.*
+### [v0.24] — Interactive Intelligence
 
-- **Custom Rules API v2 (AST Walker):** Users subclass `BaseASTRule` from `zenzic.rules`. Rules are auto-discovered from `.zenzic/rules/*.py` — no registration required.
-- **Deterministic Visitation Budget Sandbox (Z901 / Z902):** Single-threaded visitation counter guard (`max_visits = 10 000`) replaces thread-based or signal-based timeouts, preserving Windows compatibility and the $O(N)$ invariant.
-- **Auto-Fix Expansion:** `zenzic fix` now auto-repairs **Z121** (MISSING_OR_EMPTY_HREF → `href="#"`) and **Z603** (DEAD_SUPPRESSION comment/attribute removal).
-- **`fixable` metadata field:** `CodeDefinition` exposes `fixable: bool`, surfaced in `zenzic explain` and `finding-codes.md`.
+*Completing the diagnostic-to-remediation loop within the IDE.*
+
+- **VS Code Code Actions (Quick Fixes):** Implement `textDocument/codeAction` via LSP to allow users to instantly apply deterministic fixes (e.g., `Z121`, `Z603`) directly from the editor.
+- **DQS Workspace UI:** Bring the Document Quality Score (DQS) into the authoring environment via a dedicated VS Code sidebar panel, providing global repository state without leaving the editor.
+
+### [v0.25] — Deterministic Quality Platform
+
+*Evolving from a strict validator to a comprehensive quality governance engine.*
+
+- **Smart Link Graph:** Transform the Virtual Site Map (VSM) into a full topological analysis engine capable of detecting documentation islands, circular navigation paths, and unreachable clusters.
+- **Baseline & Regression Tracking:** Introduce evolutionary quality control. Essential for enterprise CI/CD to prevent DQS regressions over time.
+- **Semantic Readability Metrics:** Extend Zenzic beyond structural validation into content quality (e.g., deterministic Flesch-Kincaid scoring) while maintaining the static analysis paradigm.
+- **Configuration Validation Engine:** Reduce operational errors by establishing a single source of truth for configuration schemas across the CLI, VS Code, and documentation.
+
+### [v0.26] — Governance & Extensibility
+
+*Opening the engine to enterprise policies and custom integrations.*
+
+- **Policy-as-Code Engine:** Formalize governance by transforming scattered configurations and ADRs into a verifiable, declarative model.
+- **Custom Rule SDK v3:** Stabilize the analysis engine and sandbox to allow the community to build safe, deterministic custom rules.
+- **SARIF Enterprise Integration:** Enhance security and compliance integrations for enterprise dashboards.
+- **Zenzic Audit Mode:** High-value enterprise reporting mode requiring stable DQS, Policy Engine, and SARIF outputs.
+
+### [v0.27] — Ecosystem Expansion
+
+*Expanding the perimeter to external frameworks.*
+
+- **Docusaurus Bridge Architecture:** The first concrete implementation of the adapter ecosystem, validating the artifact-based VSM model outside the Core.
+- **Sphinx & Hugo Adapters:** Extend open-source compatibility following the stabilization of the `BaseAdapter` contract.
+- **Multi-Repository Documentation Graph:** Advanced feature to analyze documentation spanning multiple repositories, requiring full maturity of the VSM and artifact composition.
+
+### [v0.28] — Operational Excellence
+
+*Advanced observability and developer experience.*
+
+- **Performance Telemetry Engine:** Opt-in, deterministic metrics for operational governance and runtime optimization.
+- **VS Code Configuration Autocomplete:** Inject JSON Schema validation into the IDE for `.zenzic.toml` files.
 
 ---
 
-### [v0.20.1] - UI & Polyglot Leak Patch (Completed)
+## Architectural Invariants (All Milestones)
 
-- **UI dark mode restoration:** Reverted LCP optimization purging to stabilize the slate-based dark theme.
-- **Polyglot URP bypass & Z603 Dead Suppression paradox resolution:** Native HTML suppression (`data-zenzic-ignore`) correctly short-circuits the resolver pipeline (URP) and marks directives as consumed to prevent dead suppression warnings (Z603).
-
----
-
-## [v0.21.0] - Shift-Left to the Keystroke (IDE Integration & LSP)
-
-*Pushing the "Hostile Precision" feedback loop directly into the authoring environment.*
-
-- **Zenzic Language Server (ZLS) & VS Code Extension** (Issue #12): To push the "Hostile Precision" feedback loop from the CI/CD pipeline directly into the authoring environment, Zenzic will implement a native Language Server Protocol (LSP) interface.
-  - **The Architecture:** The core engine will expose a `zenzic.lsp` module (JSON-RPC over stdio). An official, thin VS Code Extension (written in TypeScript) will act purely as an LSP client.
-  - **The Single Source of Truth:** The VS Code extension will contain zero AST parsing or regex logic. It will stream `textDocument/didChange` events to the local Python backend. The Python core remains the sole arbiter of Document Quality.
-  - **Real-Time Governance:** Z-Codes will render as real-time editor diagnostics (red/yellow squiggly lines). Hovering over a broken link (`Z104`), a missing anchor (`Z102`), or a leaked credential (`Z201`) will display the exact DQS penalty and remediation steps natively extracted from the Python `CodeDefinition` registry.
-  - **Performance Invariant:** Leveraging the $O(N)$ RE2 DFA engine and atomic caching, the ZLS will guarantee sub-50ms diagnostic responses, ensuring zero typing latency degradation for the end-user.
-- **Semantic Linting & Readability** (Issues #8, #9): AST-based rules to detect semantically duplicate headings, empty/stub sections, and integration of deterministic readability metrics (Flesch-Kincaid).
-
-## [v0.22.0] - Ecosystem & Interoperability
-
-*Expanding the Zenzic perimeter to external frameworks.*
-
-- **The Bridge Architecture (TypeScript Docusaurus Plugin):** An official NPM plugin (`@zenzic/plugin-docusaurus`) that dumps a `.zenzic-vsm.json` artifact during the build.
-- **Community: Sphinx Adapter** (Issue #51): Support for parsing Sphinx `.rst` and `.md` documentation trees.
-- **Community: Hugo Adapter** (Issue #50): Support for Hugo's specific `hugo.toml` configuration and frontmatter conventions.
-- **Smart Link Graph** (Issue #7): Build a directed graph of the documentation to detect unlinked pages (islands) and navigation cycles.
-
----
-
-## Invariants (all milestones)
-
-These constraints apply across every future release:
+These constraints apply across every future release. No feature may violate them.
 
 | Invariant | Description |
 |-----------|-------------|
-| Zero Subprocess | `subprocess.Popen` and `os.system` permanently banned from `src/`. |
-| Pure Functions | The analysis engine has zero global state. |
-| DFA Guarantee | All regex matching backed by RE2. O(n) complexity. |
-| Exit Code Contract | Exit 2 = credential; Exit 3 = traversal. Never renumbered. |
-| No Inference | Zero inference-engine runtime dependencies declared in `pyproject.toml`. |
+| **Zero Subprocess** | `subprocess.Popen` and `os.system` permanently banned from `src/`. |
+| **Pure Functions** | The analysis engine has zero global state. |
+| **DFA Guarantee** | All regex matching backed by RE2. $O(N)$ complexity. |
+| **Exit Code Contract** | Exit 2 = credential; Exit 3 = traversal. Never renumbered. |
+| **No Inference** | Zero inference-engine (LLM/AI) runtime dependencies. |
+| **Radical Unawareness** | The Core remains entirely unaware of external consumers (VS Code, GitHub Actions). |
 
 ---
 
-## Known Bugs & Deferred Work
-
-No known bugs.
-
----
-
-Roadmap last updated: 2026-07-11
+Roadmap last updated: 2026-07-22.

--- a/assets/brand/svg/zenzic-wordmark-dark.svg
+++ b/assets/brand/svg/zenzic-wordmark-dark.svg
@@ -25,5 +25,5 @@
   <text x="125" y="68" font-family="system-ui, -apple-system, sans-serif" font-weight="800" font-size="56" fill="#f8fafc" letter-spacing="-1.5">Zenzic</text>
 
   <!-- Tagline -->
-  <text x="127" y="92" font-family="system-ui, -apple-system, sans-serif" font-weight="500" font-size="14" fill="#94a3b8" letter-spacing="2">DOCUMENTATION LINTER</text>
+  <text x="127" y="92" font-family="system-ui, -apple-system, sans-serif" font-weight="500" font-size="14" fill="#94a3b8" letter-spacing="2">DOCUMENT INTEGRITY ENGINE</text>
 </svg>

--- a/assets/brand/svg/zenzic-wordmark.svg
+++ b/assets/brand/svg/zenzic-wordmark.svg
@@ -25,5 +25,5 @@
   <text x="125" y="68" font-family="system-ui, -apple-system, sans-serif" font-weight="800" font-size="56" fill="#0f172a" letter-spacing="-1.5">Zenzic</text>
 
   <!-- Tagline -->
-  <text x="127" y="92" font-family="system-ui, -apple-system, sans-serif" font-weight="500" font-size="14" fill="#64748b" letter-spacing="2">DOCUMENTATION LINTER</text>
+  <text x="127" y="92" font-family="system-ui, -apple-system, sans-serif" font-weight="500" font-size="14" fill="#64748b" letter-spacing="2">DOCUMENT INTEGRITY ENGINE</text>
 </svg>

--- a/docs/assets/brand/zenzic-brand-system.html
+++ b/docs/assets/brand/zenzic-brand-system.html
@@ -1120,7 +1120,7 @@ SPDX-License-Identifier: Apache-2.0
         <p style="font-family:'Barlow Condensed',sans-serif;font-size:13px;font-weight:600;letter-spacing:0.15em;text-transform:uppercase;color:var(--muted);margin-bottom:10px">Voice</p>
         <ul style="font-family:'IBM Plex Mono',monospace;font-size:11px;color:var(--muted);line-height:2;list-style:none;padding:0">
           <li>&mdash;&nbsp; Surgical precision, never vague</li>
-          <li>&mdash;&nbsp; "Static analyzer", not "the linter"</li>
+          <li>&mdash;&nbsp; "Static analyzer", not "the legacy linter"</li>
           <li>&mdash;&nbsp; Exit codes, not "errors"</li>
           <li>&mdash;&nbsp; Findings with Z-codes, always</li>
           <li>&mdash;&nbsp; Silent on success, loud on failure</li>

--- a/docs/blog/posts/2026-05-24-engineering-v080-deep-dive.md
+++ b/docs/blog/posts/2026-05-24-engineering-v080-deep-dive.md
@@ -8,6 +8,9 @@ description: "Engineering Deep Dive: v0.8.0 Architecture"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
+!!! abstract "Architectural Update"
+    *Historical Note:* This post refers to Zenzic as a "linter". As the system evolved, its capabilities expanded far beyond surface-level linting. Zenzic is now officially classified as a **Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs**. Read the [latest documentation](https://zenzic.dev/) for current architectural capabilities.
+
 Zenzic emerged as a systems response to a recurring pattern across code reviews and CI incidents: documentation quality pipelines were improving locally but degrading structurally over time. The pipeline was shipping checks, not guarantees — collecting signals, not preserving architecture.
 
 <!-- more -->

--- a/docs/blog/posts/2026-05-27-terminal-ux-documentation-governance.md
+++ b/docs/blog/posts/2026-05-27-terminal-ux-documentation-governance.md
@@ -9,6 +9,9 @@ description: "Terminal UX as a Governance Interface: How Zenzic Renders Diagnost
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
+!!! abstract "Architectural Update"
+    *Historical Note:* This post refers to Zenzic as a "linter". As the system evolved, its capabilities expanded far beyond surface-level linting. Zenzic is now officially classified as a **Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs**. Read the [latest documentation](https://zenzic.dev/) for current architectural capabilities.
+
 A linter reports violations within individual files. A governance engine verifies
 that a set of invariants holds across the entire document graph — and halts the
 pipeline when one does not.

--- a/docs/blog/posts/2026-06-03-algorithmic-complexity-and-redos-prevention.md
+++ b/docs/blog/posts/2026-06-03-algorithmic-complexity-and-redos-prevention.md
@@ -8,6 +8,9 @@ description: "Why we banned Python's regex module: The algorithm behind Zenzic"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
+!!! abstract "Architectural Update"
+    *Historical Note:* This post refers to Zenzic as a "linter". As the system evolved, its capabilities expanded far beyond surface-level linting. Zenzic is now officially classified as a **Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs**. Read the [latest documentation](https://zenzic.dev/) for current architectural capabilities.
+
 In modern CI/CD pipelines, security and performance should be structurally bounded, not just empirically observed. Traditional documentation linters and credential scanners often fail when operating at scale or under adversarial conditions. The primary failure mode is **ReDoS (Regular Expression Denial of Service)**.
 
 <!-- more -->

--- a/docs/blog/posts/2026-06-06-native-ci-integration-and-progressive-adoption.md
+++ b/docs/blog/posts/2026-06-06-native-ci-integration-and-progressive-adoption.md
@@ -9,6 +9,9 @@ description: "Zenzic v0.10.0: Async Engine, Native Annotations, and Progressive 
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
+!!! abstract "Architectural Update"
+    *Historical Note:* This post refers to Zenzic as a "linter". As the system evolved, its capabilities expanded far beyond surface-level linting. Zenzic is now officially classified as a **Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs**. Read the [latest documentation](https://zenzic.dev/) for current architectural capabilities.
+
 Zenzic v0.10.0 introduces a massive performance upgrade with a new **Async Network Engine**, alongside two architectural changes designed strictly for the CI/CD pipeline: **Native GitHub Annotations** and **Destructive Rule Filtering**.
 
 These features are not aesthetic. They are built to solve three specific operational bottlenecks: network-induced CI flakiness, context switching during Pull Request reviews, and the high friction of adopting static analysis in legacy documentation repositories.

--- a/docs/blog/posts/2026-06-09-auditing-the-auditors.md
+++ b/docs/blog/posts/2026-06-09-auditing-the-auditors.md
@@ -9,6 +9,9 @@ description: "Auditing the Auditors: Finding Documentation Defects with AST-Base
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
+!!! abstract "Architectural Update"
+    *Historical Note:* This post refers to Zenzic as a "linter". As the system evolved, its capabilities expanded far beyond surface-level linting. Zenzic is now officially classified as a **Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs**. Read the [latest documentation](https://zenzic.dev/) for current architectural capabilities.
+
 To validate the parser and snippet-analysis capabilities of Zenzic, we needed a production-grade documentation corpus. We selected the official documentation repository of Zensical, a mature and actively maintained static site generator.
 
 The expectation was straightforward: a well-maintained documentation codebase should produce few, if any, actionable findings.

--- a/docs/blog/posts/2026-06-13-why-we-dropped-docusaurus.md
+++ b/docs/blog/posts/2026-06-13-why-we-dropped-docusaurus.md
@@ -9,6 +9,9 @@ description: "Why We Dropped Docusaurus: The Ontological Limits of Static Analys
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
+!!! abstract "Architectural Update"
+    *Historical Note:* This post refers to Zenzic as a "linter". As the system evolved, its capabilities expanded far beyond surface-level linting. Zenzic is now officially classified as a **Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs**. Read the [latest documentation](https://zenzic.dev/) for current architectural capabilities.
+
 We spent a full development cycle building a Docusaurus adapter for Zenzic.
 We ran forensic audits on real Docusaurus projects.
 Then we deleted every line of it.

--- a/docs/blog/posts/2026-06-29-10-documentation-bugs-caught-by-zenzic.md
+++ b/docs/blog/posts/2026-06-29-10-documentation-bugs-caught-by-zenzic.md
@@ -10,6 +10,9 @@ categories:
   - Documentation
   - Quality Assurance
 ---
+!!! abstract "Architectural Update"
+    *Historical Note:* This post refers to Zenzic as a "linter". As the system evolved, its capabilities expanded far beyond surface-level linting. Zenzic is now officially classified as a **Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs**. Read the [latest documentation](https://zenzic.dev/) for current architectural capabilities.
+
 Documentation isn't just text—it's a critical interface. When users rely on your docs to deploy infrastructure, configure security policies, or integrate APIs, a "simple typo" can lead to hours of lost productivity.
 
 In a docs-as-code workflow, documentation is code. And just like code, it has bugs. That's why we built Zenzic: a zero-config Markdown link and structural integrity auditor.

--- a/docs/blog/posts/2026-07-04-zenzic-v0200-the-extensibility-update.md
+++ b/docs/blog/posts/2026-07-04-zenzic-v0200-the-extensibility-update.md
@@ -15,6 +15,9 @@ categories:
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
+!!! abstract "Architectural Update"
+    *Historical Note:* This post refers to Zenzic as a "linter". As the system evolved, its capabilities expanded far beyond surface-level linting. Zenzic is now officially classified as a **Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs**. Read the [latest documentation](https://zenzic.dev/) for current architectural capabilities.
+
 Zenzic v0.20.0 is the first release to expose the engine's internal Abstract Syntax Tree to the
 outside world. After v0.19.0 laid the AST foundations, The Extensibility Update answers a
 long-standing question: *what if the rules I need simply don't exist yet?*

--- a/docs/blog/posts/2026-07-18-zenzic-vs-code-extension.md
+++ b/docs/blog/posts/2026-07-18-zenzic-vs-code-extension.md
@@ -13,6 +13,9 @@ categories:
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
+!!! abstract "Architectural Update"
+    *Historical Note:* This post refers to Zenzic as a "linter". As the system evolved, its capabilities expanded far beyond surface-level linting. Zenzic is now officially classified as a **Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs**. Read the [latest documentation](https://zenzic.dev/) for current architectural capabilities.
+
 Since its inception, Zenzic has operated as a strict, deterministic gatekeeper for CI/CD pipelines. It ensures that no broken links, malformed topology, or hardcoded credentials ever reach production.
 
 Today, we are eliminating the latency between authoring a defect and discovering it. We are officially releasing the **Zenzic VS Code Extension**, bringing the deterministic precision of our engine directly into your authoring environment.

--- a/docs/developers/explanation/governance/exit_strategy.md
+++ b/docs/developers/explanation/governance/exit_strategy.md
@@ -18,7 +18,7 @@ description: "The Sovereignty Oath of Zenzic, declaring a zero-lock-in and zero-
 Zenzic makes one unconditional promise: **it will never hold your codebase hostage.**
 
 To ensure the integrity of the Privacy Gate, Zenzic's audit core is strictly read-only.
-We believe that a linter should never be a source of unintended mutations. Any future
+We believe that a document integrity engine should never be a source of unintended mutations. Any future
 remediation features will be implemented as explicit, interactive utilities
 (e.g. `zenzic fix`), keeping the analysis phase 100% mutation-free.
 

--- a/docs/developers/explanation/governance/technical-debt.md
+++ b/docs/developers/explanation/governance/technical-debt.md
@@ -50,7 +50,7 @@ The check is conceptually simple but architecturally expensive:
    validator pass would force a Pillar 3 redesign in a release cycle whose stated
    goal is *consolidation*, not refactor.
 2. **Wrong category.** Linting the *content* of documentation and linting
-   the *configuration* of the linter itself are different problem spaces.
+   the *configuration* of the engine itself are different problem spaces.
    Mixing them inflates the validator's scope and obscures which findings
    are about user-authored content vs. project setup.
 3. **YAGNI signal absent.** No real-world reports of stale allowlist
@@ -88,7 +88,7 @@ will name the version that resolved it and link to the merged PR.
 
 ## Why this page exists
 
-Zenzic's first invariant is **Transparency**. A linter that hides its own
+Zenzic's first invariant is **Transparency**. An analysis engine that hides its own
 shortcomings is not trustworthy: every project that adopts Zenzic should be
 able to read this ledger and judge for themselves whether the deferred work
 matters to their use case.

--- a/docs/developers/how-to/implement-adapter.md
+++ b/docs/developers/how-to/implement-adapter.md
@@ -299,7 +299,7 @@ def get_link_scheme_bypasses(self) -> frozenset[str]:
     return frozenset()
 ```
 
-Most engines return `frozenset()`. An engine might use custom link schemes to bypass routing (for example, to reference static assets that bypass the central router). The adapter registers these custom schemes to prevent the core linter from flagging them as absolute paths.
+Most engines return `frozenset()`. An engine might use custom link schemes to bypass routing (for example, to reference static assets that bypass the central router). The adapter registers these custom schemes to prevent the core engine from flagging them as absolute paths.
 
 !!! info "Rule R21 — Protocol Sovereignty"
     The Core never hardcodes engine names. Engine-specific behaviour is declared in

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -255,7 +255,7 @@ Adapters that support frontmatter `slug` overrides map slugs into the Virtual Si
 
 However, Zenzic's **link integrity** validation (broken links, absolute paths) resolves relative paths from the *filesystem* location, not the slug URL. This means a heavy divergence between slug and file path can cause a page's relative links to resolve differently in Zenzic (file-based) vs the build engine (URL-based).
 
-**Architectural invariant:** keep the filesystem hierarchy aligned with the intended URL hierarchy. If a file is moved to a new directory, let the URL follow naturally rather than using `slug` to pin the old URL. This ensures `../` links resolve identically in both the linter and the static-site generator.
+**Architectural invariant:** keep the filesystem hierarchy aligned with the intended URL hierarchy. If a file is moved to a new directory, let the URL follow naturally rather than using `slug` to pin the old URL. This ensures `../` links resolve identically in both the integrity engine and the static-site generator.
 
 ### Alias Mapping in `InMemoryPathResolver` {#alias-mapping}
 
@@ -548,7 +548,7 @@ participant in the quality pipeline. Every commit runs `zenzic check all --stric
 itself before it can be pushed (Sovereign Parity, ZRT-010).
 
 Beyond the standard Zenzic audit, `zenzic-doc` enforces a second invariant unique to its
-role as documentation for a linter: every Zxxx finding code present in `docs/` must have a
+role as documentation for an integrity engine: every Zxxx finding code present in `docs/` must have a
 registered entry in `src/zenzic/core/codes.py` in the Core package — and vice versa. This
 bidirectional parity is enforced by the `verify-codes-parity` Nox session via
 **Sovereign Resolution (Fail-Closed)**:

--- a/docs/explanation/community-index.md
+++ b/docs/explanation/community-index.md
@@ -8,7 +8,7 @@ description: "Community resources, contribution guides, and project governance."
 
 # About Zenzic
 
-Zenzic is an engineering-grade documentation linter and quality gate for any Markdown-based project.
+Zenzic is a Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs.
 
 Built by [PythonWoods](https://github.com/PythonWoods), it is designed to run in CI/CD pipelines and catch documentation issues before they reach users.
 

--- a/docs/explanation/exclusion-design.md
+++ b/docs/explanation/exclusion-design.md
@@ -12,7 +12,7 @@ description: "The design rationale behind Zenzic's conscious exclusion model ver
 
 Zenzic defaults to **Conscious Control** rather than Blind Automation. Understanding this principle is the key to configuring the tool effectively in production projects.
 
-`respect_vcs_ignore` is `true` by default. This aligns Zenzic with modern linter behavior: VCS-ignored paths are skipped unless explicitly included.
+`respect_vcs_ignore` is `true` by default. This aligns Zenzic with modern static analysis behavior: VCS-ignored paths are skipped unless explicitly included.
 
 **The Noisy `.gitignore` Problem**
 
@@ -27,7 +27,7 @@ htmlcov/
 .venv/
 ```
 
-If `respect_vcs_ignore = true`, Zenzic would silently exclude any documentation file whose path matches these patterns. A `docs/coverage-report.md` page, for instance, would vanish from orphan detection without any diagnostic message. The linter would appear healthy while silently skipping entire documentation subtrees.
+If `respect_vcs_ignore = true`, Zenzic would silently exclude any documentation file whose path matches these patterns. A `docs/coverage-report.md` page, for instance, would vanish from orphan detection without any diagnostic message. The engine would appear healthy while silently skipping entire documentation subtrees.
 
 **The Explicit `.zenzic.toml` is Superior**
 

--- a/docs/explanation/structural-integrity.md
+++ b/docs/explanation/structural-integrity.md
@@ -103,12 +103,12 @@ contract between the author and every tool in the pipeline.
 
 ## The Node.js Tax and Architectural Independence {#the-nodejs-tax}
 
-You might ask: why does Zenzic implement `Z505 (Untagged Code Blocks)` when linters
+You might ask: why does Zenzic implement `Z505 (Untagged Code Blocks)` when static analysis tools
 like `markdownlint` already detect this?
 
 The answer is **[Pillar 2: Zero Subprocesses](./the-zenzic-trinity.md)**.
 
-Traditional Markdown linters require a full Node.js runtime and hundreds of megabytes of
+Traditional Markdown tools require a full Node.js runtime and hundreds of megabytes of
 `node_modules`. For a Python-based DevOps pipeline, a security-conscious enterprise, or any
 team running CI in a minimal container, this dependency creates friction: additional toolchain
 configuration, runtime version pinning, and transitive supply-chain exposure. We call this
@@ -126,7 +126,7 @@ npm audit surface      Zero transitive risk
 
 By providing core structural checks in pure Python, Zenzic enables professional-grade
 documentation quality **without leaving your primary technology stack**. Zenzic is not
-designed to replace every linter in your pipeline — but for structural integrity, security,
+designed to replace every quality check in your pipeline — but for structural integrity, security,
 and technical accessibility in CI, it is the only one you **need**.
 
 ---

--- a/docs/explanation/the-zenzic-trinity.md
+++ b/docs/explanation/the-zenzic-trinity.md
@@ -10,7 +10,7 @@ description: "How the three Zenzic repositories form a Trinity of Integrity — 
 
 ## The Zenzic Trinity: Code, Doc, and Action
 
-Zenzic is more than a linter. It is a **Sovereign Knowledge System** — an ecosystem where
+Zenzic is a **Sovereign Knowledge System** — an ecosystem where
 logic, intent, and enforcement are permanently synchronized. To deliver a true
 [Exclusion Zone](./privacy-gate.md), Zenzic is organized into a Trinity of Integrity: three
 repositories that form a closed feedback loop, each reinforcing the others.

--- a/docs/explanation/why-zenzic.md
+++ b/docs/explanation/why-zenzic.md
@@ -9,7 +9,7 @@ description: "How Zenzic reduces documentation risk, removes manual QA loops, an
 
 # Why Zenzic — Risk Prevention and Deterministic Quality Gates
 
-Zenzic is a high-performance documentation linter for any Markdown-based project. It operates on raw source files — never the generated output — so it works with any build engine (MkDocs, Zensical, or others via the adapter system). It detects broken links, orphan pages, placeholder stubs, unused assets, and leaked credentials before the build runs.
+Zenzic is a Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs. It operates on raw source files — never the generated output — so it works with any build engine (MkDocs, Zensical, or others via the adapter system). It detects broken links, orphan pages, placeholder stubs, unused assets, and leaked credentials before the build runs.
 
 Zenzic exists to prevent documentation defects from entering the main branch. The objective is
 operational: block regressions before release, reduce security exposure, and keep CI outcomes

--- a/docs/how-to/configure-social-metadata.md
+++ b/docs/how-to/configure-social-metadata.md
@@ -43,7 +43,7 @@ Any page can override the global defaults by adding fields to its frontmatter:
 title: "Architecture — How Zenzic Works"
 description: "Deep dive into the Two-Pass Pipeline, VSM, and path traversal guard."
 image: assets/social/social-card.png
-keywords: [zenzic, architecture, vsm, pipeline, documentation linter]
+keywords: [zenzic, architecture, vsm, pipeline, document integrity engine]
 ---
 ```
 

--- a/docs/how-to/migrate-engines.md
+++ b/docs/how-to/migrate-engines.md
@@ -9,7 +9,7 @@ description: "Upgrade guides and migration notes between Zenzic versions."
 # Migrating to Zensical
 
 !!! note "Zenzic vs Zensical"
-    **Zenzic** is the documentation linter described in this documentation site — the tool
+    **Zenzic** is the document integrity engine described in this documentation site — the tool
     you run with `zenzic check all`.
 
     **Zensical** is a separate build engine (a compatible successor to MkDocs 1.x). This page
@@ -48,7 +48,7 @@ touching a single documentation file. From Zenzic's perspective:
 
 When using `mkdocs-material` with the `i18n` plugin and multiple locales, the language
 switcher can be controlled by two different mechanisms. Mixing them causes routing conflicts
-that Zenzic — a source linter — cannot detect automatically, but that silently break the
+that Zenzic — a source-level SAST engine — cannot detect automatically, but that silently break the
 user experience at build time.
 
 **Recommended configuration:**

--- a/docs/reference/advanced-features.md
+++ b/docs/reference/advanced-features.md
@@ -80,7 +80,7 @@ applies a defence-in-depth pass to non-definition lines to catch secrets in plai
 | `slack-token` | `xox[baprs]-[0-9a-zA-Z]{10,48}` | Slack bot/user/app tokens |
 | `google-api-key` | `AIza[0-9A-Za-z\-_]{35}` | Google Cloud / Maps API keys |
 | `private-key` | `-----BEGIN [A-Z ]+ PRIVATE KEY-----` | PEM private keys (RSA, EC, etc.) |
-| `hex-encoded-payload` | `(?:\\x[0-9a-fA-F]{2}){3,}` | Detects obfuscation attempts that hide payloads or credentials via hex escapes. This technique is commonly used to evade naive string linters and is treated as a critical source-transparency violation. |
+| `hex-encoded-payload` | `(?:\x[0-9a-fA-F]{2}){3,}` | Detects obfuscation attempts that hide payloads or credentials via hex escapes. This technique is commonly used to evade naive string matchers and is treated as a critical source-transparency violation. |
 
 ### credential scanner behaviour {#credential-scanner-behaviour}
 

--- a/docs/reference/checks.md
+++ b/docs/reference/checks.md
@@ -73,7 +73,7 @@ Servers returning `401`, `403`, or `429` are treated as reachable — these indi
 
     Some build engines allow frontmatter `slug` overrides that decouple a page's URL from its filesystem location. When this happens, the "parent directory" for relative link resolution may differ between the build engine (which resolves from the URL) and Zenzic (which resolves from the file path).
 
-    **Best practice:** keep the filesystem structure aligned with the URL structure. If you move a file to `guides/checks.md`, let its URL become `/docs/guides/checks` rather than forcing a slug back to `/docs/checks`. This guarantees that `../` links resolve identically for both the linter and the build engine.
+    **Best practice:** keep the filesystem structure aligned with the URL structure. If you move a file to `guides/checks.md`, let its URL become `/docs/guides/checks` rather than forcing a slug back to `/docs/checks`. This guarantees that `../` links resolve identically for both the integrity engine and the build engine.
 
 **Zenzic output — gutter reporter:**
 

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -858,7 +858,7 @@ move all settings that follow that header to the top of the file, before any `[s
 
 ### Dogfooding Pattern with Zensical/MkDocs {#dogfooding}
 
-Documenting a linter with its own linter creates intentional false positives: pages that *explain* placeholder patterns will trigger the placeholder checker.
+Documenting an integrity engine with its own analysis tool creates intentional false positives: pages that *explain* placeholder patterns will trigger the placeholder checker.
 Disable the checker in the `.zenzic.toml` of the documentation repository:
 
 ```toml

--- a/docs/reference/scoring-algorithm.md
+++ b/docs/reference/scoring-algorithm.md
@@ -118,7 +118,7 @@ $$
 | Z601 | BRAND_OBSOLESCENCE | 2.0 pts | Governance |
 
 !!! note Z106 — Knowledge Graph telemetry, not a defect
-    Z106 is excluded from the penalty table by design. Elevating it to a scored finding would deduct Quality Score points, pressuring engineers to remove cross-links to satisfy the linter — a perverse incentive that degrades real documentation quality. Circular links in a Knowledge Graph are structural data, not defects. Z106 is emitted as topological telemetry; inspect it with `--show-info`.
+    Z106 is excluded from the penalty table by design. Elevating it to a scored finding would deduct Quality Score points, pressuring engineers to remove cross-links to satisfy the quality gate — a perverse incentive that degrades real documentation quality. Circular links in a Knowledge Graph are structural data, not defects. Z106 is emitted as topological telemetry; inspect it with `--show-info`.
 
 !!! note Z602 is not scored
     Z602 (I18N_PARITY) is a Governance gate that fires as a standalone finding. It does not contribute to any DQS bucket and therefore has no penalty value in the table above.

--- a/justfile
+++ b/justfile
@@ -68,7 +68,7 @@ test-full *args:
 
 # ─── Quality Gates (4-Lifecycle-Gates model) ──────────────────────────────────
 
-# Fast linter pass: run all pre-commit hooks without the full test suite.
+# Fast static check pass: run all pre-commit hooks without the full test suite.
 lint:
     {{ runner }} pre-commit run --all-files
 
@@ -87,7 +87,7 @@ verify: _check-hooks release-contracts check-pinning docs-build
     {{ runner }} zenzic score --check-stamp --ci
 
 # ADR-089 — Immutable Infrastructure guard on local hooks (internal CI policy,
-# not a public Zenzic linter rule). Pre-commit `rev:` keys must be 40-char
+# not a public Zenzic rule). Pre-commit `rev:` keys must be 40-char
 # commit SHAs, not mutable tags. Regex anchored to line-start so the
 # `# vX.Y.Z` annotation comment is safe.
 check-pinning:
@@ -107,7 +107,7 @@ _check-hooks:
     _missing=0
     if [ ! -f .git/hooks/pre-commit ]; then
         echo -e "\033[33m⚠️  WARNING: pre-commit hook is not installed.\033[0m"
-        echo "Without it, linters and type-checks will NOT run automatically on git commit."
+        echo "Without it, static checks and type-checks will NOT run automatically on git commit."
         echo "👉 Fix it by running: uv run --active pre-commit install"
         echo ""
         _missing=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,12 @@ build-backend = "hatchling.build"
 [project]
 name = "zenzic"
 version = "0.23.1"
-description = "Engineering-grade, engine-agnostic static analyzer and credential scanner for Markdown documentation"
+description = "Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs."
 readme = "README.md"
 requires-python = ">=3.10"
 # PEP 639: SPDX expression string (replaces deprecated `license = { text = "..." }`)
 license = "Apache-2.0"
-keywords = ["static-analysis", "security", "documentation", "semver", "linter", "ci", "strict", "links", "mkdocs", "zensical", "yaml", "json", "toml"]
+keywords = ["static-analysis", "security", "documentation", "semver", "sast", "graph-topology", "ci", "strict", "links", "mkdocs", "zensical", "yaml", "json", "toml"]
 classifiers = [
 
  # ─── Version bumping ───────────────────────────────────────────────────────────

--- a/src/zenzic/core/adapters/_factory.py
+++ b/src/zenzic/core/adapters/_factory.py
@@ -26,7 +26,7 @@ When ``from_repo`` is absent the factory falls back to calling
 Fallback
 --------
 When no entry point matches the requested engine, :class:`StandaloneAdapter` is
-returned.  This keeps Zenzic functional as a plain Markdown linter even when
+returned.  This keeps Zenzic functional as a standalone document integrity analyzer even when
 the docs engine is not installed.
 """
 

--- a/src/zenzic/core/adapters/_standalone.py
+++ b/src/zenzic/core/adapters/_standalone.py
@@ -19,7 +19,7 @@ class StandaloneAdapter(BaseAdapter):
 
     Returned by :func:`~zenzic.core.adapters.get_adapter` when neither a
     ``mkdocs.yml`` nor explicit locales are detected.  Provides neutral,
-    no-op behaviour so Zenzic operates as a plain Markdown linter without
+    no-op behaviour so Zenzic operates as a standalone document integrity analyzer without
     any i18n awareness.
 
     In Standalone Mode, navigation-based checks (orphans) are disabled

--- a/src/zenzic/core/adapters/_utils.py
+++ b/src/zenzic/core/adapters/_utils.py
@@ -39,7 +39,7 @@ def case_sensitive_exists(path: Path) -> bool:
     On case-insensitive filesystems (Windows NTFS, macOS HFS+), ``Path.exists()``
     returns ``True`` even when the on-disk filename differs only in case from the
     requested name.  Web servers and browsers are case-sensitive, so
-    ``Logo.png`` and ``logo.png`` are different resources; a linter must
+    ``Logo.png`` and ``logo.png`` are different resources; static analysis must
     reflect that.
 
     This function uses ``os.listdir(path.parent)`` — which always returns the

--- a/src/zenzic/core/validator.py
+++ b/src/zenzic/core/validator.py
@@ -973,7 +973,7 @@ async def _check_external_links(
 
     headers = {
         "User-Agent": (
-            "Zenzic-Documentation-Linter/0.1.0 (+https://github.com/PythonWoods/zenzic)"
+            "Zenzic-Document-Integrity-Engine/0.1.0 (+https://github.com/PythonWoods/zenzic)"
         ),
         "Accept": "text/html,application/xhtml+xml,*/*",
     }

--- a/src/zenzic/models/config.py
+++ b/src/zenzic/models/config.py
@@ -402,7 +402,7 @@ class ZenzicConfig(BaseModel):
         description=(
             "When True (default), Zenzic reads .gitignore files from the "
             "repository root and docs directory and excludes matching paths "
-            "from all checks. This aligns with industry-grade linter standards "
+            "from all checks. This aligns with industry-grade static analysis standards "
             "(Ruff, Ripgrep, Black, Prettier) where VCS-ignored paths are "
             "transparently excluded. Set to False only to override this "
             "behaviour explicitly. Forced inclusions (included_dirs, "

--- a/static/assets/brand/svg/zenzic-wordmark-dark.svg
+++ b/static/assets/brand/svg/zenzic-wordmark-dark.svg
@@ -25,5 +25,5 @@
   <text x="125" y="68" font-family="system-ui, -apple-system, sans-serif" font-weight="800" font-size="56" fill="#f8fafc" letter-spacing="-1.5">Zenzic</text>
 
   <!-- Tagline -->
-  <text x="127" y="92" font-family="system-ui, -apple-system, sans-serif" font-weight="500" font-size="14" fill="#94a3b8" letter-spacing="2">DOCUMENTATION LINTER</text>
+  <text x="127" y="92" font-family="system-ui, -apple-system, sans-serif" font-weight="500" font-size="14" fill="#94a3b8" letter-spacing="2">DOCUMENT INTEGRITY ENGINE</text>
 </svg>

--- a/static/assets/brand/svg/zenzic-wordmark.svg
+++ b/static/assets/brand/svg/zenzic-wordmark.svg
@@ -25,5 +25,5 @@
   <text x="125" y="68" font-family="system-ui, -apple-system, sans-serif" font-weight="800" font-size="56" fill="#0f172a" letter-spacing="-1.5">Zenzic</text>
 
   <!-- Tagline -->
-  <text x="127" y="92" font-family="system-ui, -apple-system, sans-serif" font-weight="500" font-size="14" fill="#64748b" letter-spacing="2">DOCUMENTATION LINTER</text>
+  <text x="127" y="92" font-family="system-ui, -apple-system, sans-serif" font-weight="500" font-size="14" fill="#64748b" letter-spacing="2">DOCUMENT INTEGRITY ENGINE</text>
 </svg>

--- a/tests/test_protocol_evolution.py
+++ b/tests/test_protocol_evolution.py
@@ -140,8 +140,8 @@ class TestFrontmatterExtraction:
         assert extract_frontmatter_unlisted(content) is False
 
     def test_tags_inline(self) -> None:
-        content = "---\ntags: [python, docs, linter]\n---\n\nBody"
-        assert extract_frontmatter_tags(content) == ["python", "docs", "linter"]
+        content = "---\ntags: [python, docs, sast]\n---\n\nBody"
+        assert extract_frontmatter_tags(content) == ["python", "docs", "sast"]
 
     def test_tags_flow(self) -> None:
         content = "---\ntags:\n- python\n- docs\n---\n\nBody"

--- a/tests/test_vsm.py
+++ b/tests/test_vsm.py
@@ -579,7 +579,7 @@ class TestUnreachableLinkDetection:
 
     def test_conflict_route_not_emitting_unreachable_link(self, tmp_path: Path) -> None:
         """A CONFLICT route is a build error, not an unreachable link per se.
-        The linter should not double-report it as UNREACHABLE_LINK."""
+        The engine should not double-report it as UNREACHABLE_LINK."""
         _make_docs(
             tmp_path,
             {


### PR DESCRIPTION
## Objective
Eradicate the "linter" classification across the Zenzic Core repository and realign all documentation, manifests, SVGs, and roadmaps with Zenzic's architectural identity: **Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs**.

## Key Changes
- **Manifests & Brand Assets**: Updated `pyproject.toml` description and keywords (`sast`, `graph-topology`), as well as brand SVGs.
- **Documentation & Guides**: Reordered feature lists across `README.md` to prioritize SAST (Z2xx rules), Graph Topology Analysis (VSM), and Deterministic CI/CD Enforcement. Purged "linter" references across active docs.
- **Ecosystem Roadmap Unification (ECOSYSTEM-ROADMAP-002)**: Updated `ROADMAP.md` to be strictly forward-looking (`v0.24`–`v0.28`), removing historical changelogs and adding P0 infrastructural priorities (Empirical Benchmark Suite and OIDC integration).
- **Historical Immutability (REPO-ALIGN-003)**: Injected `!!! abstract "Architectural Update"` callouts into historical blog posts.

## Verification
- Pre-push quality gates (`just verify`) passed.
- Global grep confirms 0 occurrences of "linter" in active code and documentation.