### PR TITLE
fix(lsp): enforce strict file and domain discovery boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,13 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install just
         uses: taiki-e/install-action@ea85faa6acd705ad6d40586db99f1a70b09c2929 # just
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,15 +39,15 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v3

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
 
@@ -58,7 +58,7 @@ jobs:
 
       - name: Publish GitHub release (tags only)
         if: github.ref_type == 'tag'
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           files: ${{ steps.vars.outputs.name }}.tar.gz
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
 
@@ -38,7 +38,7 @@ jobs:
         run: zip -qr brand-kit.zip assets/brand/
 
       - name: Generate build provenance attestation
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/*
 
@@ -48,7 +48,7 @@ jobs:
       # -------------------------------------
 
       - name: Generate GitHub Release
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           files: |
             dist/*

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Generate SBOM (Syft — spdx-json)
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0

--- a/.github/workflows/security-posture.yml
+++ b/.github/workflows/security-posture.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check for SECURITY.md
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **LSP Discovery Boundaries (`ZLS-DISCOVERY-001`, `ZLS-DISCOVERY-002`)**: Enforced strict Domain-Aware Discovery in the LSP server to silently drop non-Markdown files and files outside the configured docs_dir.
+
 ## [0.23.1] - 2026-07-22
 
 ### Added

--- a/docs/architecture/lsp-integration.md
+++ b/docs/architecture/lsp-integration.md
@@ -72,8 +72,8 @@ The engine executes the following deterministic O(K) pipeline:
 
 To uphold ADR-075 (Radical Unawareness), the Zenzic Language Server core contains zero editor-specific code. Thin client integrations (such as `zenzic-vscode`) execute a pre-initialization version check before opening JSON-RPC streams:
 
-1. **Minimum Core Baseline**: Client extensions must define and enforce a minimum required Zenzic Core version (e.g., via a MIN_CORE_VERSION constant) to ensure compatibility with the expected LSP feature set.
+1. **Minimum Core Baseline**: Client extensions define and enforce a minimum required Zenzic Core version (`MIN_CORE_VERSION`) to guarantee feature set compatibility.
 2. **Execution Safety**: Client extensions execute `<executablePath> --version` via `child_process.execFile` (disabling shell interpolation to eliminate injection vectors).
-3. **Fail-Fast Error Handling**:
-   - **`Zenzic: Outdated Core`**: Surfaced when the resolved binary version is lower than the minimum required baseline. Resolution: `uv tool install --force zenzic`.
-   - **`Zenzic: Not Found (ENOENT)`**: Surfaced when the binary is absent from `$PATH` (e.g. Snap/Flatpak isolation). Resolution: configure absolute path in `zenzic.executablePath`.
+3. **Transport Handshake**: The client verifies the core version before starting stdin/stdout stdio streams.
+
+For user-facing installation, configuration, and editor troubleshooting, see the [VS Code Extension User Guide](../editor/vscode.md).

--- a/docs/editor/vscode.md
+++ b/docs/editor/vscode.md
@@ -1,0 +1,104 @@
+<!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Zenzic VS Code Extension
+
+The official **Zenzic VS Code Extension** (`pythonwoods.zenzic-vscode`) brings sub-50ms deterministic diagnostics, credential scanning, and real-time topological validation directly into your authoring environment.
+
+## Thin Client Architecture
+
+The extension is designed as a **Thin Client**. It contains zero parsing engines, zero regex logic, and zero validation rules.
+
+Instead, it relies on the Language Server Protocol (LSP) over `stdio` to communicate directly with your local Zenzic Python binary (`zenzic lsp`). This guarantees 100% parity between local editor feedback and CI/CD pipeline enforcement.
+
+```text
+┌─────────────────────────┐   JSON-RPC 2.0 (stdio)   ┌──────────────────────────────┐
+│  VS Code Extension      ├─────────────────────────►│  Zenzic Language Server      │
+│  (pythonwoods-vscode)   │◄─────────────────────────┤  (zenzic lsp)                │
+└─────────────────────────┘                          └──────────────────────────────┘
+```
+
+## Requirements & Baseline
+
+- **Zenzic Core**: v0.23.1 or higher installed on your system or virtual environment.
+- **VS Code**: v1.125.0 or higher.
+
+## Installation
+
+### 1. Install the Core Engine
+
+The VS Code extension requires the Zenzic Python core binary to perform analysis:
+
+```bash
+uv tool install --force zenzic
+```
+
+Alternatively, install via `pip` or inside your active virtual environment:
+
+```bash
+pip install zenzic
+```
+
+### 2. Install the Extension
+
+Search for **Zenzic** in the VS Code Extensions panel (`Ctrl+Shift+X` / `Cmd+Shift+X`), or install via the VS Code CLI:
+
+```bash
+code --install-extension pythonwoods.zenzic-vscode
+```
+
+## Configuration
+
+The extension automatically discovers `zenzic` in standard `$PATH` directories and user bin locations (`~/.local/bin`, `~/.cargo/bin`, `~/.uv/bin`).
+
+If you use a custom virtual environment or isolated installation, configure `zenzic.executablePath` in your VS Code `settings.json`:
+
+```json
+{
+  "zenzic.executablePath": "${workspaceFolder}/.venv/bin/zenzic"
+}
+```
+
+### Supported Settings
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `zenzic.executablePath` | `string` | `"zenzic"` | Absolute path or binary name for the Zenzic executable. |
+
+## Domain Boundaries & Supported Files
+
+To uphold **Domain-Aware Discovery** and **Radical Unawareness**:
+
+- **File Extensions**: The extension and Language Server exclusively target Markdown (`.md`) and MDX (`.mdx`) files. Non-documentation files (e.g. `OWNERS`, `.gitignore`, `config.yaml`) are automatically filtered out.
+- **Configured Domain**: Only files residing within the configured `docs_dir` (default: `docs/`) or `extra_content_roots` are evaluated. Out-of-bounds files in the workspace (such as root `README.md` when `docs_dir = "docs"`) produce zero diagnostics.
+
+## Troubleshooting
+
+### `Zenzic: Not Found (ENOENT)`
+
+**Symptom:** Status bar shows `$(error) Zenzic: Not Found` or prompt reads *Zenzic binary not found*.
+
+**Cause:** The `zenzic` executable is not installed or not present in system `$PATH` / standard user directories (`~/.local/bin`, `~/.uv/bin`).
+
+**Resolution:**
+1. Install Zenzic globally via `uv tool install zenzic`.
+2. Or configure `zenzic.executablePath` in VS Code settings with the full path to your virtual environment binary (e.g., `/home/user/project/.venv/bin/zenzic`).
+
+### `Zenzic: Outdated Core`
+
+**Symptom:** Status bar shows `$(error) Zenzic: Outdated Core` or notification requests upgrading.
+
+**Cause:** The installed Zenzic Core binary version is lower than the required minimum baseline (`v0.23.1`).
+
+**Resolution:** Update the Zenzic executable to the latest version:
+
+```bash
+uv tool install --force zenzic
+```
+
+### Server Version Check Errors
+
+**Symptom:** Notification reads *Could not verify Zenzic Core version*.
+
+**Cause:** Executing `zenzic --version` returned an error or non-zero exit code.
+
+**Resolution:** Verify that `zenzic --version` runs cleanly in your terminal and check permissions on `zenzic.executablePath`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,8 @@ nav:
       - how-to/use-brand-system.md
       - how-to/workflow-integration.md
       - how-to/configure-social-metadata.md
+    - Editor Integration:
+      - editor/vscode.md
     - Reference:
       - reference/index.md
       - reference/finding-codes.md

--- a/src/zenzic/core/incremental.py
+++ b/src/zenzic/core/incremental.py
@@ -155,7 +155,7 @@ class IncrementalAnalysisEngine:
         Returns:
             Mapping of file URI to list of ``ZenzicDiagnostic`` instances.
         """
-        from zenzic.core.discovery import iter_markdown_sources
+        from zenzic.core.discovery import DOC_SUFFIXES, iter_markdown_sources
         from zenzic.core.exclusion import LayeredExclusionManager
 
         # Force full sync on first invocation
@@ -190,6 +190,8 @@ class IncrementalAnalysisEngine:
             for buf_uri, buf_text in overlay.buffers.items():
                 if buf_uri.startswith("file://"):
                     buf_path = Path(buf_uri[7:]).resolve()
+                    if buf_path.suffix.lower() not in DOC_SUFFIXES:
+                        continue
                     if buf_path not in self.md_contents_cache:
                         self.md_contents_cache[buf_path] = buf_text
                         self.anchors_cache[buf_path] = anchors_in_file(buf_text)
@@ -200,6 +202,8 @@ class IncrementalAnalysisEngine:
                 if not uri.startswith("file://"):
                     continue
                 path = Path(uri[7:]).resolve()
+                if path.suffix.lower() not in DOC_SUFFIXES:
+                    continue
                 if uri in overlay.buffers:
                     text = overlay.buffers[uri]
                     self.md_contents_cache[path] = text

--- a/src/zenzic/lsp/server.py
+++ b/src/zenzic/lsp/server.py
@@ -12,9 +12,10 @@ import time
 import traceback
 from pathlib import Path
 from typing import Any, BinaryIO, TypedDict, cast
+from urllib.parse import unquote, urlsplit
 
 from zenzic.core.adapters import BaseAdapter, get_adapter
-from zenzic.core.discovery import iter_markdown_sources
+from zenzic.core.discovery import DOC_SUFFIXES, iter_markdown_sources
 from zenzic.core.exclusion import LayeredExclusionManager
 from zenzic.core.incremental import IncrementalAnalysisEngine
 from zenzic.core.rules import AdaptiveRuleEngine
@@ -226,6 +227,47 @@ class LanguageServer:
         )
         self._flush_dirty_documents()
 
+    def _is_supported_doc_uri(self, uri: str) -> bool:
+        """Return True if the URI has a supported documentation file extension (DOC_SUFFIXES)."""
+        if not uri:
+            return False
+        parsed = urlsplit(uri)
+        path_str = unquote(parsed.path) if parsed.scheme else unquote(uri)
+        return Path(path_str).suffix.lower() in DOC_SUFFIXES
+
+    def _is_within_domain(self, uri: str) -> bool:
+        """Return True if the URI is within the configured documentation domain."""
+        if not uri or self.repo_root is None:
+            return True
+
+        try:
+            if not self.config:
+                self.config, _ = ZenzicConfig.load(self.repo_root)
+
+            docs_root = (self.repo_root / self.config.docs_dir).resolve()
+            if not docs_root.is_dir():
+                docs_root = self.repo_root.resolve()
+
+            parsed = urlsplit(uri)
+            path_str = unquote(parsed.path) if parsed.scheme else unquote(uri)
+            path = Path(path_str).resolve()
+
+            if path.is_relative_to(docs_root):
+                return True
+
+            if not self.adapter:
+                self.adapter = get_adapter(self.config.build_context, docs_root, self.repo_root)
+
+            if self.adapter:
+                extra_roots = self.adapter.get_extra_content_roots(self.repo_root)
+                for extra_root in extra_roots:
+                    if path.is_relative_to(extra_root.resolve()):
+                        return True
+        except Exception:
+            return False
+
+        return False
+
     def _handle_file_changes(self, changes: list[dict[str, Any]]) -> None:
         """Incrementally update file caches and trigger revalidation."""
         if self.vsm is None or not self.adapter or not self.config:
@@ -236,7 +278,11 @@ class LanguageServer:
         for change in changes:
             uri = change.get("uri", "")
             change_type = change.get("type")
-            if not uri.startswith("file://"):
+            if (
+                not uri.startswith("file://")
+                or not self._is_supported_doc_uri(uri)
+                or not self._is_within_domain(uri)
+            ):
                 continue
             file_path = Path(uri[7:]).resolve()
 
@@ -322,15 +368,19 @@ class LanguageServer:
             self.exit_received = True
             self.exit_code = 0 if self.shutdown_received else 1
         elif method == "textDocument/didOpen":
-            self.documents.did_open(params)
             uri = params.get("textDocument", {}).get("uri", "")
+            if not self._is_supported_doc_uri(uri) or not self._is_within_domain(uri):
+                return
+            self.documents.did_open(params)
             if uri in self.documents.documents:
                 if self.overlay:
                     self.overlay.update(uri, self.documents.documents[uri])
                 self.dirty_documents[uri] = time.time()
         elif method == "textDocument/didChange":
-            self.documents.did_change(params)
             uri = params.get("textDocument", {}).get("uri", "")
+            if not self._is_supported_doc_uri(uri) or not self._is_within_domain(uri):
+                return
+            self.documents.did_change(params)
             if uri in self.documents.documents:
                 if self.overlay:
                     self.overlay.update(uri, self.documents.documents[uri])

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -632,3 +632,101 @@ def test_lsp_security_rules_masking() -> None:
 
     assert found_z203, "Z203 MUST be emitted for /etc/passwd"
     assert not found_z101, "Z101 MUST be masked by Z203"
+
+
+def test_is_supported_doc_uri() -> None:
+    """Verify _is_supported_doc_uri correctly identifies supported doc extensions."""
+    server = LanguageServer()
+    assert server._is_supported_doc_uri("file:///repo/docs/readme.md") is True
+    assert server._is_supported_doc_uri("file:///repo/docs/page.mdx") is True
+    assert server._is_supported_doc_uri("file:///repo/i18n/OWNERS") is False
+    assert server._is_supported_doc_uri("file:///repo/config.yaml") is False
+    assert server._is_supported_doc_uri("file:///repo/.gitignore") is False
+    assert server._is_supported_doc_uri("") is False
+
+
+def test_lsp_drops_non_markdown_did_open(tmp_path) -> None:
+    """Verify that textDocument/didOpen for non-markdown files (OWNERS, yaml, txt) is dropped."""
+    server = LanguageServer()
+    owners_uri = f"file://{tmp_path}/i18n/OWNERS"
+    yaml_uri = f"file://{tmp_path}/config.yaml"
+    md_uri = f"file://{tmp_path}/docs/index.md"
+
+    # Non-markdown files must be dropped
+    server.handle_message({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {"textDocument": {"uri": owners_uri, "text": "reviewers:\n- sig-docs\n"}},
+    })
+    assert owners_uri not in server.documents.documents
+    assert owners_uri not in server.dirty_documents
+
+    server.handle_message({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {"textDocument": {"uri": yaml_uri, "text": "key: value\n"}},
+    })
+    assert yaml_uri not in server.documents.documents
+    assert yaml_uri not in server.dirty_documents
+
+    # Markdown file must be accepted
+    server.handle_message({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {"textDocument": {"uri": md_uri, "text": "# Hello World\n"}},
+    })
+    assert md_uri in server.documents.documents
+    assert md_uri in server.dirty_documents
+
+
+def test_is_within_domain(tmp_path) -> None:
+    """Verify _is_within_domain respects repo_root and docs_dir boundaries."""
+    server = LanguageServer()
+    # Null workspace allows any file
+    assert server._is_within_domain(f"file://{tmp_path}/README.md") is True
+
+    # Active workspace with default docs_dir="docs"
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    server.repo_root = tmp_path
+
+    assert server._is_within_domain(f"file://{docs_dir}/index.md") is True
+    assert server._is_within_domain(f"file://{tmp_path}/README.md") is False
+    assert server._is_within_domain(f"file://{tmp_path}/other/page.md") is False
+
+
+def test_lsp_drops_out_of_bounds_markdown_did_open(tmp_path) -> None:
+    """Verify that textDocument/didOpen for out-of-bounds .md files (e.g. root README.md when docs_dir='docs') is dropped."""
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    in_bounds_md = docs_dir / "index.md"
+    in_bounds_md.write_text("# Docs Index\nThis is a valid documentation page with enough content.\n")
+
+    out_bounds_md = tmp_path / "README.md"
+    out_bounds_md.write_text("# Root Readme\nShort content.\n")
+
+    server = LanguageServer()
+    server.repo_root = tmp_path
+
+    in_uri = f"file://{in_bounds_md.resolve()}"
+    out_uri = f"file://{out_bounds_md.resolve()}"
+
+    # Out-of-bounds .md file must be dropped
+    server.handle_message({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {"textDocument": {"uri": out_uri, "text": "# Root Readme\nShort content.\n"}},
+    })
+    assert out_uri not in server.documents.documents
+    assert out_uri not in server.dirty_documents
+
+    # In-bounds .md file must be accepted
+    server.handle_message({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {"textDocument": {"uri": in_uri, "text": "# Docs Index\nThis is a valid documentation page.\n"}},
+    })
+    assert in_uri in server.documents.documents
+    assert in_uri in server.dirty_documents
+
+


### PR DESCRIPTION
## Summary
- Enforces strict file extension check (`.md`, `.mdx`) in Language Server via `_is_supported_doc_uri` (`ZLS-DISCOVERY-001`).
- Enforces Domain-Aware Discovery in Language Server via `_is_within_domain` (`ZLS-DISCOVERY-002`), dropping out-of-bounds file payloads.
- Restructures Information Architecture to introduce Editor Integration user guide (`DOCS-IA-001`).