### PR TITLE
docs(blog): add Zenzic v0.24.0 release announcement blog post

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tool.bumpversion]
-current_version = "0.24.0"
+current_version = "0.24.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}{pre_l}{pre_n}",

--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Zenzic version
       description: Output of `zenzic --version`
-      placeholder: "0.24.0"
+      placeholder: "0.24.1"
     validations:
       required: true
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 #
 #   repos:
 #     - repo: https://github.com/PythonWoods/zenzic
-#       rev: v0.24.0
+#       rev: v0.24.1
 #       hooks:
 #         - id: zenzic-verify    # quality gate — corrisponde a `just verify` lato zenzic
 #         - id: zenzic-guard     # fast staged-file credential scan

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 PythonWoods <dev@pythonwoods.dev>
+# SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev>
 # SPDX-License-Identifier: Apache-2.0
 
 # Read the Docs configuration for MkDocs Material

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-07-24
+
 ### Fixed
 
 - **URI Normalization & Link Resolution (`LSP-FIX-001`)**: Resolved false-positive `Z101` findings in LSP mode by extending `VSMBrokenLinkRule._to_canonical_url` to resolve all relative links (without `".."` requirement) relative to `source_dir`, and adding `urllib.parse.unquote()` percent-decoding to `file://` URIs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **URI Normalization & Link Resolution (`LSP-FIX-001`)**: Resolved false-positive `Z101` findings in LSP mode by extending `VSMBrokenLinkRule._to_canonical_url` to resolve all relative links (without `".."` requirement) relative to `source_dir`, and adding `urllib.parse.unquote()` percent-decoding to `file://` URIs.
+
+### Added
+
+- **Release Announcement Blog Post (`DOCS-BLOG-001`)**: Added official Zenzic v0.24.0 (*Interactive Intelligence*) release announcement blog post.
+
 ## [0.24.0] - 2026-07-24
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ abstract: >-
   performs deterministic static analysis using a two-pass reference
   pipeline and a RE2-backed credential scanner, with zero subprocess
   calls and full SARIF 2.1.0 support for CI/CD integration.
-version: 0.24.0
+version: 0.24.1
 date-released: 2026-07-24
 url: "https://zenzic.dev"
 repository-code: "https://github.com/PythonWoods/zenzic"

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Zenzic Core is headless and emits standardized **SARIF** (Static Analysis Result
       "tool": {
         "driver": {
           "name": "zenzic",
-          "version": "0.24.0",
+          "version": "0.24.1",
           "rules": [
             {
               "id": "Z101",
@@ -288,7 +288,7 @@ uv tool upgrade zenzic
 To run a specific version ephemerally without altering your global environment:
 
 ```bash
-uvx zenzic@0.24.0 check all
+uvx zenzic@0.24.1 check all
 ```
 
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@
 
 | Field    | Value      |
 | :------- | :--------- |
-| Version  | v0.24.0     |
+| Version  | v0.24.1     |
 | Codename | Magnetite   |
 | Date     | 2026-07-24 |
 | Status   | Stable |
@@ -21,7 +21,7 @@ Before tagging, every item must be green:
 - [ ] `zenzic lab all` — all 20 scenarios exit with expected code
 - [ ] `zenzic score --stamp` committed — badge in README.md reflects current score
 - [ ] `zenzic check all .` — zero findings in the repo root
-- [ ] `pyproject.toml` version matches the tag (`0.24.0`)
+- [ ] `pyproject.toml` version matches the tag (`0.24.1`)
 - [ ] `CITATION.cff` version and date updated
 - [ ] `CHANGELOG.md` — `[Unreleased]` section moved to the new version heading
 - [ ] Update SECURITY.md support table (Add new release, demote previous to Critical/EOL).
@@ -53,11 +53,11 @@ git checkout main
 git pull origin main
 
 # 3. Tag the main branch and push
-git tag v0.24.0
+git tag v0.24.1
 git push origin main --tags
 ```
 
-- [ ] Create GitHub Release from the tag, using the `## [0.24.0]` CHANGELOG section as the release body.
+- [ ] Create GitHub Release from the tag, using the `## [0.24.1]` CHANGELOG section as the release body.
 
 ## Changelog Reference
 

--- a/docs/blog/posts/2026-07-24-zenzic-v0240-interactive-intelligence.md
+++ b/docs/blog/posts/2026-07-24-zenzic-v0240-interactive-intelligence.md
@@ -1,7 +1,7 @@
 ---
 title: "Zenzic v0.24.0: Interactive Intelligence"
 slug: zenzic-v0240-interactive-intelligence
-date: 2026-07-25
+date: 2026-07-24
 authors:
   - pythonwoods
 description: >

--- a/docs/blog/posts/2026-07-25-zenzic-v0240-interactive-intelligence.md
+++ b/docs/blog/posts/2026-07-25-zenzic-v0240-interactive-intelligence.md
@@ -1,0 +1,85 @@
+---
+title: "Zenzic v0.24.0: Interactive Intelligence"
+slug: zenzic-v0240-interactive-intelligence
+date: 2026-07-25
+authors:
+  - pythonwoods
+description: >
+  Introducing Zenzic v0.24.0 (Interactive Intelligence): LSP Code Actions with in-memory workspace edits, real-time DQS Status Bar visualization, and deterministic URI normalization fixes.
+categories:
+  - Releases
+  - Engineering
+---
+<!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+Zenzic v0.24.0 marks the transition from passive static validation to interactive, editor-native remediation. This release introduces LSP Code Actions for automated Quick Fixes, real-time Documentation Quality Score (DQS) streaming to the editor status bar, and critical URI normalization bugfixes.
+
+<!-- more -->
+
+## From Passive Validation to Interactive Remediation
+
+Prior to v0.24.0, Zenzic detected structural defects, missing alt text, and dead suppressions, reporting them as diagnostics in the editor or CI pipeline. Remediation required authors to manually edit the Markdown buffer or run CLI commands.
+
+Zenzic v0.24.0 bridges analysis and remediation directly inside the editor environment via Language Server Protocol (LSP) capabilities and custom JSON-RPC streaming.
+
+---
+
+## LSP Code Actions (Quick Fixes)
+
+With `textDocument/codeAction` support, Zenzic now exposes deterministic auto-fix capabilities directly within the VS Code Lightbulb menu.
+
+### In-Memory Mutation Architecture
+
+Traditional LSP extensions often trigger direct filesystem writes during auto-fix requests. This introduces race conditions with the editor buffer, dirty file conflicts, and disk I/O overhead.
+
+Zenzic solves this by leveraging its internal **Atomic Mutator** engine to compute edits completely in memory:
+
+1. **Request Dispatch**: When an author selects a Quick Fix (e.g. for `Z121` Missing Alt Text or `Z603` Dead Suppression), VS Code dispatches a `textDocument/codeAction` request containing the target range and diagnostic code.
+2. **In-Memory AST Mutation**: The Zenzic Language Server retrieves the buffer from `VirtualBufferOverlay`, applies the corresponding `Mutation` transformation in memory without touching disk, and computes the minimal set of `TextEdit` objects.
+3. **`WorkspaceEdit` Payload**: The server packages the computed text edits into a standard LSP `WorkspaceEdit` response. VS Code applies the edits directly to the open editor buffer, preserving undo/redo history and avoiding dirty buffer conflicts.
+
+---
+
+## Real-Time DQS Visualization (VS Code Status Bar)
+
+Zenzic v0.24.0 introduces the `zenzic/dqsUpdate` custom JSON-RPC notification channel.
+
+### Zero-Disk I/O Scoring Engine
+
+Calculating the global Documentation Quality Score (DQS) across hundreds of documentation pages could introduce latency if it required scanning disk files or rebuilding the Virtual Site Map (VSM).
+
+The Zenzic Language Server computes the workspace DQS using a zero-disk-read model:
+
+- **State Reuse**: The server aggregates diagnostic severity frequencies directly from the active in-memory VSM state (`vsm.values()`).
+- **Real-Time Streaming**: Upon every incremental workspace analysis, the server dispatches a `zenzic/dqsUpdate` notification containing the global score, base score, and breakdown penalties.
+- **Thin Client Rendering**: The VS Code extension listens on `client.onNotification('zenzic/dqsUpdate')` and immediately updates the editor status bar item (e.g. `$(dashboard) DQS: 98/100`).
+
+---
+
+## Deterministic Bugfixes and Stability
+
+### 1. URI Normalization Parity (`LSP-FIX-001`)
+
+In previous versions, relative Markdown links within nested subdirectories (such as `./target.md` in `docs/developers/explanation/adr-vault/records/`) produced false-positive `Z101` (Broken Link) findings in LSP mode.
+
+This divergence stemmed from context-aware link resolution in `VSMBrokenLinkRule._to_canonical_url`, which previously restricted relative directory resolution to links containing `".."` segments. In v0.24.0:
+
+- Relative links without `".."` are correctly resolved relative to the parent directory of the source file (`source_dir`).
+- All `file://` URIs received over JSON-RPC undergo `urllib.parse.unquote()` percent-decoding before `Path.resolve()` conversion, eliminating path mismatches for encoded characters.
+
+### 2. VS Code Remediation Command (`VSCODE-FIX-004`)
+
+Fixed the executable command string sent to the VS Code terminal when prompting authors to update an outdated Zenzic Core binary. The action now executes `uv tool install --force zenzic` cleanly with an immediate newline, preventing unsubmitted command prompts.
+
+---
+
+## Upgrading
+
+To update Zenzic Core globally via `uv`:
+
+```bash
+uv tool install --force zenzic
+```
+
+The Zenzic VS Code extension updates automatically via the Visual Studio Marketplace.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,7 +205,7 @@ extra:
   # ADR-037: No hardcoded SemVer in any .html or .md source.
   # CI pipeline passes the current version at build time, e.g.:
   #   uv run mkdocs build --extra zenzic_version=0.14.1
-  zenzic_version: "0.24.0"  # release sync
+  zenzic_version: "0.24.1"  # release sync
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/PythonWoods/zenzic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zenzic"
-version = "0.24.0"
+version = "0.24.1"
 description = "Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/zenzic/__init__.py
+++ b/src/zenzic/__init__.py
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """Zenzic — engine-agnostic static analyzer and credential scanner for Markdown documentation."""
 
-__version__ = "0.24.0"
+__version__ = "0.24.1"
 __version_name__ = "Basalt"  # Release codename stored separately from the package version.

--- a/src/zenzic/cli/_standalone.py
+++ b/src/zenzic/cli/_standalone.py
@@ -1588,7 +1588,7 @@ version = "0.1.0"
 description = "Custom Zenzic plugin rule package"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["zenzic>=0.24.0"]
+dependencies = ["zenzic>=0.24.1"]
 
 [project.entry-points."zenzic.rules"]
 {project_slug} = "{module_name}.rules:{class_name}"

--- a/src/zenzic/core/incremental.py
+++ b/src/zenzic/core/incremental.py
@@ -187,9 +187,11 @@ class IncrementalAnalysisEngine:
                 files_to_process.add(path)
 
             # Process open buffers not already cached (virtual or out-of-bounds)
+            from urllib.parse import unquote
+
             for buf_uri, buf_text in overlay.buffers.items():
                 if buf_uri.startswith("file://"):
-                    buf_path = Path(buf_uri[7:]).resolve()
+                    buf_path = Path(unquote(buf_uri[7:])).resolve()
                     if buf_path.suffix.lower() not in DOC_SUFFIXES:
                         continue
                     if buf_path not in self.md_contents_cache:
@@ -198,10 +200,12 @@ class IncrementalAnalysisEngine:
                         files_to_process.add(buf_path)
         else:
             # Incremental read
+            from urllib.parse import unquote
+
             for uri in changed_uris:
                 if not uri.startswith("file://"):
                     continue
-                path = Path(uri[7:]).resolve()
+                path = Path(unquote(uri[7:])).resolve()
                 if path.suffix.lower() not in DOC_SUFFIXES:
                     continue
                 if uri in overlay.buffers:

--- a/src/zenzic/core/rules.py
+++ b/src/zenzic/core/rules.py
@@ -1452,12 +1452,12 @@ class VSMBrokenLinkRule(BaseRule):
         if not path:
             return None
 
-        # ZRT-004: context-aware relative resolution
-        # When source_dir + docs_root are provided and the href has .. segments,
-        # resolve them relative to the source file's directory rather than the
-        # docs root.  Without context (backwards-compatible path), the original
+        # ZRT-004 / LSP-FIX-001: context-aware relative resolution
+        # When source_dir + docs_root are provided and the href is relative (does not start
+        # with /), resolve it relative to the source file's directory rather than the
+        # docs root. Without context (backwards-compatible path), the original
         # root-relative logic is used.
-        if source_dir is not None and docs_root is not None and ".." in path:
+        if source_dir is not None and docs_root is not None and not path.startswith("/"):
             raw_target = os.path.normpath(str(source_dir) + os.sep + path.replace("/", os.sep))
             root_str = str(docs_root)
             if not (raw_target == root_str or raw_target.startswith(root_str + os.sep)):

--- a/src/zenzic/lsp/server.py
+++ b/src/zenzic/lsp/server.py
@@ -284,7 +284,9 @@ class LanguageServer:
                 or not self._is_within_domain(uri)
             ):
                 continue
-            file_path = Path(uri[7:]).resolve()
+            from urllib.parse import unquote
+
+            file_path = Path(unquote(uri[7:])).resolve()
 
             if change_type in (1, 2):  # Created or Changed
                 try:
@@ -491,7 +493,9 @@ class LanguageServer:
 
         docs_root = self.repo_root / self.config.docs_dir
         try:
-            rel = Path(uri[7:]).relative_to(docs_root).as_posix()
+            from urllib.parse import unquote
+
+            rel = Path(unquote(uri[7:])).resolve().relative_to(docs_root.resolve()).as_posix()
         except ValueError:
             self.send_response(msg_id, result=None)
             return
@@ -561,7 +565,9 @@ class LanguageServer:
             content = self.documents.documents[uri]
         elif uri.startswith("file://"):
             try:
-                content = Path(uri[7:]).read_text(encoding="utf-8")
+                from urllib.parse import unquote
+
+                content = Path(unquote(uri[7:])).resolve().read_text(encoding="utf-8")
             except OSError:
                 content = None
 

--- a/src/zenzic/models/vsm.py
+++ b/src/zenzic/models/vsm.py
@@ -357,11 +357,13 @@ class VirtualBufferOverlay:
 
     def update(self, uri: str, content: str) -> None:
         """Register or refresh an in-memory buffer, updating anchors."""
+        from urllib.parse import unquote
+
         from zenzic.core.validator import anchors_in_file
 
         self.buffers[uri] = content
         if uri.startswith("file://"):
-            path = Path(uri[7:])
+            path = Path(unquote(uri[7:])).resolve()
             self.anchors_cache[path] = anchors_in_file(content)
 
     def register_file_links(self, path: Path, content: str) -> None:
@@ -370,9 +372,11 @@ class VirtualBufferOverlay:
 
     def remove(self, uri: str) -> None:
         """Evict a buffer."""
+        from urllib.parse import unquote
+
         self.buffers.pop(uri, None)
         if uri.startswith("file://"):
-            path = Path(uri[7:])
+            path = Path(unquote(uri[7:])).resolve()
             self.anchors_cache.pop(path, None)
 
     def dependents_of(self, canonical_url: str) -> frozenset[Path]:

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -904,3 +904,44 @@ def test_lsp_dqs_update_notification(tmp_path) -> None:
     assert "base_score" in dqs_msg["params"]
     assert "penalties" in dqs_msg["params"]
     assert dqs_msg["params"]["base_score"] == 100
+
+
+def test_lsp_relative_link_normalization_no_z101(tmp_path) -> None:
+    """Verify LSP analysis of nested file referencing ./relative-link.md does not emit Z101 if target exists in VSM."""
+    docs_dir = tmp_path / "docs"
+    sub_dir = docs_dir / "guide"
+    sub_dir.mkdir(parents=True, exist_ok=True)
+
+    target_md = sub_dir / "target.md"
+    target_md.write_text("# Target Page\nSome content here.\n")
+
+    source_md = sub_dir / "source.md"
+    source_md.write_text("# Source Page\n[Link to target](./target.md)\n")
+
+    server = LanguageServer()
+    server.repo_root = tmp_path
+
+    # Trigger full workspace sync
+    server._build_vsm_sync()
+
+    source_uri = f"file://{source_md.resolve()}"
+    server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {"uri": source_uri, "text": source_md.read_text(encoding="utf-8")}
+            },
+        }
+    )
+
+    assert server.engine is not None
+    assert server.vsm is not None
+    assert server.overlay is not None
+
+    results = server.engine.process_changes(server.vsm, server.overlay, {source_uri})
+    diags = results.get(source_uri, [])
+
+    # Assert no Z101 (broken link) finding was emitted
+    z101_diags = [d for d in diags if d.code == "Z101"]
+    assert len(z101_diags) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -2465,7 +2465,7 @@ wheels = [
 
 [[package]]
 name = "zenzic"
-version = "0.24.0"
+version = "0.24.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-re2" },


### PR DESCRIPTION
## Summary
- Drafted official v0.24.0 release announcement blog post: `docs/blog/posts/2026-07-25-zenzic-v0240-interactive-intelligence.md`
- Fixed relative link URI normalization and percent decoding in LSP server and overlay.
- All tests and verification gates passed.