### PR TITLE
fix(lsp): enforce LayeredExclusionManager, asset resolution, and initialization DQS sync

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tool.bumpversion]
-current_version = "0.24.1"
+current_version = "0.24.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}{pre_l}{pre_n}",

--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Zenzic version
       description: Output of `zenzic --version`
-      placeholder: "0.24.1"
+      placeholder: "0.24.2"
     validations:
       required: true
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 #
 #   repos:
 #     - repo: https://github.com/PythonWoods/zenzic
-#       rev: v0.24.1
+#       rev: v0.24.2
 #       hooks:
 #         - id: zenzic-verify    # quality gate — corrisponde a `just verify` lato zenzic
 #         - id: zenzic-guard     # fast staged-file credential scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **LSP Layered Exclusion & Asset Resolution (`LSP-FIX-002`)**: Enforced `LayeredExclusionManager` filtering in `LanguageServer._is_within_domain()` and `_build_vsm_sync()` so configured `excluded_dirs` are respected in editor sessions. Registered static HTML and media assets in VSM during initialization to eliminate false-positive `Z101` broken link errors on asset references.
+- **LSP Workspace Initialization Sync (`LSP-FIX-003`)**: Added initial workspace analysis and `zenzic/dqsUpdate` JSON-RPC broadcast upon receiving the `initialized` notification, ensuring editor DQS widgets reflect repository quality state prior to explicit `textDocument/didOpen` events.
+
 ## [0.24.1] - 2026-07-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.24.2] - 2026-07-24
+
 ### Fixed
 
 - **LSP Layered Exclusion & Asset Resolution (`LSP-FIX-002`)**: Enforced `LayeredExclusionManager` filtering in `LanguageServer._is_within_domain()` and `_build_vsm_sync()` so configured `excluded_dirs` are respected in editor sessions. Registered static HTML and media assets in VSM during initialization to eliminate false-positive `Z101` broken link errors on asset references.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ abstract: >-
   performs deterministic static analysis using a two-pass reference
   pipeline and a RE2-backed credential scanner, with zero subprocess
   calls and full SARIF 2.1.0 support for CI/CD integration.
-version: 0.24.1
+version: 0.24.2
 date-released: 2026-07-24
 url: "https://zenzic.dev"
 repository-code: "https://github.com/PythonWoods/zenzic"

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Zenzic Core is headless and emits standardized **SARIF** (Static Analysis Result
       "tool": {
         "driver": {
           "name": "zenzic",
-          "version": "0.24.1",
+          "version": "0.24.2",
           "rules": [
             {
               "id": "Z101",
@@ -288,7 +288,7 @@ uv tool upgrade zenzic
 To run a specific version ephemerally without altering your global environment:
 
 ```bash
-uvx zenzic@0.24.1 check all
+uvx zenzic@0.24.2 check all
 ```
 
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@
 
 | Field    | Value      |
 | :------- | :--------- |
-| Version  | v0.24.1     |
+| Version  | v0.24.2     |
 | Codename | Magnetite   |
 | Date     | 2026-07-24 |
 | Status   | Stable |
@@ -21,7 +21,7 @@ Before tagging, every item must be green:
 - [ ] `zenzic lab all` — all 20 scenarios exit with expected code
 - [ ] `zenzic score --stamp` committed — badge in README.md reflects current score
 - [ ] `zenzic check all .` — zero findings in the repo root
-- [ ] `pyproject.toml` version matches the tag (`0.24.1`)
+- [ ] `pyproject.toml` version matches the tag (`0.24.2`)
 - [ ] `CITATION.cff` version and date updated
 - [ ] `CHANGELOG.md` — `[Unreleased]` section moved to the new version heading
 - [ ] Update SECURITY.md support table (Add new release, demote previous to Critical/EOL).
@@ -53,11 +53,11 @@ git checkout main
 git pull origin main
 
 # 3. Tag the main branch and push
-git tag v0.24.1
+git tag v0.24.2
 git push origin main --tags
 ```
 
-- [ ] Create GitHub Release from the tag, using the `## [0.24.1]` CHANGELOG section as the release body.
+- [ ] Create GitHub Release from the tag, using the `## [0.24.2]` CHANGELOG section as the release body.
 
 ## Changelog Reference
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,7 +205,7 @@ extra:
   # ADR-037: No hardcoded SemVer in any .html or .md source.
   # CI pipeline passes the current version at build time, e.g.:
   #   uv run mkdocs build --extra zenzic_version=0.14.1
-  zenzic_version: "0.24.1"  # release sync
+  zenzic_version: "0.24.2"  # release sync
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/PythonWoods/zenzic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zenzic"
-version = "0.24.1"
+version = "0.24.2"
 description = "Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/zenzic/__init__.py
+++ b/src/zenzic/__init__.py
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """Zenzic — engine-agnostic static analyzer and credential scanner for Markdown documentation."""
 
-__version__ = "0.24.1"
+__version__ = "0.24.2"
 __version_name__ = "Basalt"  # Release codename stored separately from the package version.

--- a/src/zenzic/cli/_standalone.py
+++ b/src/zenzic/cli/_standalone.py
@@ -1588,7 +1588,7 @@ version = "0.1.0"
 description = "Custom Zenzic plugin rule package"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["zenzic>=0.24.1"]
+dependencies = ["zenzic>=0.24.2"]
 
 [project.entry-points."zenzic.rules"]
 {project_slug} = "{module_name}.rules:{class_name}"

--- a/src/zenzic/core/__init__.py
+++ b/src/zenzic/core/__init__.py
@@ -11,7 +11,8 @@ Import the incremental analysis engine::
     from zenzic.core import IncrementalAnalysisEngine
 """
 
-from zenzic.core.incremental import IncrementalAnalysisEngine
+from typing import TYPE_CHECKING, Any
+
 from zenzic.core.resolver import (
     AnchorMissing,
     FileNotFound,
@@ -20,6 +21,18 @@ from zenzic.core.resolver import (
     Resolved,
     ResolveOutcome,
 )
+
+
+if TYPE_CHECKING:
+    from zenzic.core.incremental import IncrementalAnalysisEngine
+
+
+def __getattr__(name: str) -> Any:
+    if name == "IncrementalAnalysisEngine":
+        from zenzic.core.incremental import IncrementalAnalysisEngine
+
+        return IncrementalAnalysisEngine
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [

--- a/src/zenzic/core/incremental.py
+++ b/src/zenzic/core/incremental.py
@@ -155,7 +155,7 @@ class IncrementalAnalysisEngine:
         Returns:
             Mapping of file URI to list of ``ZenzicDiagnostic`` instances.
         """
-        from zenzic.core.discovery import DOC_SUFFIXES, iter_markdown_sources
+        from zenzic.core.discovery import DOC_SUFFIXES, iter_markdown_sources, walk_files
         from zenzic.core.exclusion import LayeredExclusionManager
 
         # Force full sync on first invocation
@@ -185,6 +185,23 @@ class IncrementalAnalysisEngine:
                 self.md_contents_cache[path] = text
                 self.anchors_cache[path] = anchors_in_file(text)
                 files_to_process.add(path)
+
+            # Static asset files (HTML, images, etc.) under docs_root
+            if self.docs_root.is_dir():
+                for file_path in walk_files(
+                    self.docs_root, set(self.config.excluded_dirs), exclusion_manager, self.config
+                ):
+                    if (
+                        file_path.is_dir()
+                        or file_path.is_symlink()
+                        or file_path.suffix in DOC_SUFFIXES
+                    ):
+                        continue
+                    if exclusion_manager.should_exclude_file(file_path, self.docs_root):
+                        continue
+                    resolved_path = file_path.resolve()
+                    if resolved_path not in self.md_contents_cache:
+                        self.md_contents_cache[resolved_path] = ""
 
             # Process open buffers not already cached (virtual or out-of-bounds)
             from urllib.parse import unquote

--- a/src/zenzic/core/rules.py
+++ b/src/zenzic/core/rules.py
@@ -1376,20 +1376,21 @@ class VSMBrokenLinkRule(BaseRule):
                     )
                 )
             elif route.status == "ORPHAN_BUT_EXISTING":
-                violations.append(
-                    Violation(
-                        file_path=file_path,
-                        line_no=lineno,
-                        code="Z103",
-                        message=(
-                            f"'{url}' resolves to '{target_url}' which exists on disk "
-                            f"but is not in the site navigation (ORPHAN_LINK). "
-                            "Readers cannot reach this page via the nav tree."
-                        ),
-                        level="warning",
-                        context=raw_line,
+                if Path(route.source).suffix.lower() in (".md", ".mdx"):
+                    violations.append(
+                        Violation(
+                            file_path=file_path,
+                            line_no=lineno,
+                            code="Z103",
+                            message=(
+                                f"'{url}' resolves to '{target_url}' which exists on disk "
+                                f"but is not in the site navigation (ORPHAN_LINK). "
+                                "Readers cannot reach this page via the nav tree."
+                            ),
+                            level="warning",
+                            context=raw_line,
+                        )
                     )
-                )
             elif route.status not in ("REACHABLE",):
                 violations.append(
                     Violation(
@@ -1468,9 +1469,10 @@ class VSMBrokenLinkRule(BaseRule):
                 return None
             path = rel if rel != "." else ""
 
-        # Strip .md suffix if present
-        if path.endswith(".md"):
-            path = path[:-3]
+        # Strip .md, .mdx, .html, .htm suffix if present
+        ext = Path(path).suffix.lower()
+        if ext in (".md", ".mdx", ".html", ".htm"):
+            path = path[: -len(ext)]
 
         # index is the directory itself
         parts = [p for p in path.split("/") if p]

--- a/src/zenzic/lsp/server.py
+++ b/src/zenzic/lsp/server.py
@@ -15,7 +15,7 @@ from typing import Any, BinaryIO, TypedDict, cast
 from urllib.parse import unquote, urlsplit
 
 from zenzic.core.adapters import BaseAdapter, get_adapter
-from zenzic.core.discovery import DOC_SUFFIXES, iter_markdown_sources
+from zenzic.core.discovery import DOC_SUFFIXES, iter_markdown_sources, walk_files
 from zenzic.core.exclusion import LayeredExclusionManager
 from zenzic.core.incremental import IncrementalAnalysisEngine
 from zenzic.core.rules import AdaptiveRuleEngine
@@ -52,6 +52,7 @@ class LanguageServer:
         # Phase 2: Diagnostic Engine
         self.config: ZenzicConfig | None = None
         self.rule_engine: AdaptiveRuleEngine | None = None
+        self.exclusion_mgr: LayeredExclusionManager | None = None
 
         # Phase 3: Debounce
         self.dirty_documents: dict[str, float] = {}
@@ -197,16 +198,30 @@ class LanguageServer:
             self.rule_engine = _build_rule_engine(self.config)
 
         docs_root = self.repo_root / self.config.docs_dir
-        exclusion_mgr = LayeredExclusionManager(
-            self.config, repo_root=self.repo_root, docs_root=docs_root
-        )
+        if not self.exclusion_mgr:
+            self.exclusion_mgr = LayeredExclusionManager(
+                self.config, repo_root=self.repo_root, docs_root=docs_root
+            )
 
         md_contents: dict[Path, str] = {}
-        for md_file in iter_markdown_sources(docs_root, self.config, exclusion_mgr):
+        for md_file in iter_markdown_sources(docs_root, self.config, self.exclusion_mgr):
             try:
                 md_contents[md_file.resolve()] = md_file.read_text(encoding="utf-8")
             except OSError:
                 continue
+
+        # Register static asset files (HTML, images, etc.) present in docs_root into VSM
+        if docs_root.is_dir():
+            for file_path in walk_files(
+                docs_root, set(self.config.excluded_dirs), self.exclusion_mgr, self.config
+            ):
+                if file_path.is_dir() or file_path.is_symlink() or file_path.suffix in DOC_SUFFIXES:
+                    continue
+                if self.exclusion_mgr.should_exclude_file(file_path, docs_root):
+                    continue
+                resolved_path = file_path.resolve()
+                if resolved_path not in md_contents:
+                    md_contents[resolved_path] = ""
 
         self.adapter = get_adapter(self.config.build_context, docs_root, self.repo_root)
         self.vsm = build_vsm(self.adapter, docs_root, md_contents, repo_root=self.repo_root)
@@ -236,7 +251,7 @@ class LanguageServer:
         return Path(path_str).suffix.lower() in DOC_SUFFIXES
 
     def _is_within_domain(self, uri: str) -> bool:
-        """Return True if the URI is within the configured documentation domain."""
+        """Return True if the URI is within the configured documentation domain and not excluded."""
         if not uri or self.repo_root is None:
             return True
 
@@ -248,9 +263,18 @@ class LanguageServer:
             if not docs_root.is_dir():
                 docs_root = self.repo_root.resolve()
 
+            if not self.exclusion_mgr:
+                self.exclusion_mgr = LayeredExclusionManager(
+                    self.config, repo_root=self.repo_root, docs_root=docs_root
+                )
+
             parsed = urlsplit(uri)
             path_str = unquote(parsed.path) if parsed.scheme else unquote(uri)
             path = Path(path_str).resolve()
+
+            # Enforce LayeredExclusionManager (Layer 3 User Exclusions & Guardrails)
+            if self.exclusion_mgr.should_exclude_file(path, docs_root):
+                return False
 
             if path.is_relative_to(docs_root):
                 return True
@@ -361,6 +385,7 @@ class LanguageServer:
                     }
                 )
                 self._build_vsm_sync()
+                self._sync_workspace_and_publish()
         elif method == "workspace/didChangeWatchedFiles":
             self._handle_file_changes(params.get("changes", []))
         elif method == "shutdown":

--- a/src/zenzic/models/config.py
+++ b/src/zenzic/models/config.py
@@ -16,7 +16,8 @@ from typing import Any, Final, Literal
 
 from pydantic import BaseModel, Field, PrivateAttr, field_validator
 
-from zenzic.core import regex as re
+import zenzic.core.regex as re
+from zenzic.core.regex import RegexPattern
 from zenzic.core.ui import ZenzicPalette
 
 
@@ -534,12 +535,12 @@ class ZenzicConfig(BaseModel):
         ),
     )
     # Pre-compiled regex patterns (not serializable, runtime only)
-    placeholder_patterns_compiled: list[re.RegexPattern] = Field(
+    placeholder_patterns_compiled: list[RegexPattern] = Field(
         default_factory=list,
         exclude=True,
         repr=False,
     )
-    forbidden_patterns_compiled: re.RegexPattern | None = Field(
+    forbidden_patterns_compiled: RegexPattern | None = Field(
         default=None,
         exclude=True,
         repr=False,

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -945,3 +945,104 @@ def test_lsp_relative_link_normalization_no_z101(tmp_path) -> None:
     # Assert no Z101 (broken link) finding was emitted
     z101_diags = [d for d in diags if d.code == "Z101"]
     assert len(z101_diags) == 0
+
+
+def test_lsp_workspace_initialization_emits_initial_dqs(tmp_path) -> None:
+    """Verify that initialized handler triggers workspace sync and emits initial DQS update without opening files."""
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    index_md = docs_dir / "index.md"
+    index_md.write_text("# Home\nWelcome home.\n")
+
+    stdin = io.BytesIO()
+    stdout = io.BytesIO()
+    server = LanguageServer(stdin=stdin, stdout=stdout)
+
+    init_msg = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {"rootUri": f"file://{tmp_path.resolve()}"},
+    }
+    initialized_msg = {"jsonrpc": "2.0", "method": "initialized", "params": {}}
+
+    server.handle_message(init_msg)
+    server.handle_message(initialized_msg)
+
+    stdout.seek(0)
+    raw_output = stdout.read().decode("utf-8")
+
+    assert "zenzic/dqsUpdate" in raw_output
+    assert server.vsm is not None
+    assert server.engine is not None
+
+
+def test_lsp_excluded_files_produce_no_diagnostics(tmp_path) -> None:
+    """Verify that files inside excluded_dirs (from .zenzic.toml) are dropped by LSP handlers and produce 0 diagnostics."""
+    config_file = tmp_path / ".zenzic.toml"
+    config_file.write_text('docs_dir = "docs"\nexcluded_dirs = ["docs/tutorials/examples"]\n')
+
+    docs_dir = tmp_path / "docs"
+    ex_dir = docs_dir / "tutorials" / "examples"
+    ex_dir.mkdir(parents=True, exist_ok=True)
+
+    ex_file = ex_dir / "z501-placeholder.md"
+    ex_file.write_text("# Malformed Example\n[Bad link](http://broken-domain-999.invalid)\n")
+
+    server = LanguageServer()
+    server.repo_root = tmp_path
+    server._build_vsm_sync()
+
+    ex_uri = f"file://{ex_file.resolve()}"
+    assert not server._is_within_domain(ex_uri)
+
+    server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {"uri": ex_uri, "text": ex_file.read_text(encoding="utf-8")}
+            },
+        }
+    )
+
+    # Document was dropped by domain / exclusion gate
+    assert ex_uri not in server.documents.documents
+
+
+def test_lsp_html_asset_links_resolve_without_z101(tmp_path) -> None:
+    """Verify that links to static HTML assets register in VSM and do not produce Z101 diagnostics."""
+    docs_dir = tmp_path / "docs"
+    assets_dir = docs_dir / "assets"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+
+    html_asset = assets_dir / "diagram.html"
+    html_asset.write_text("<html><body>Diagram</body></html>")
+
+    source_md = docs_dir / "index.md"
+    source_md.write_text("# Home\n[See Diagram](./assets/diagram.html)\n")
+
+    server = LanguageServer()
+    server.repo_root = tmp_path
+    server._build_vsm_sync()
+
+    source_uri = f"file://{source_md.resolve()}"
+    server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {"uri": source_uri, "text": source_md.read_text(encoding="utf-8")}
+            },
+        }
+    )
+
+    assert server.vsm is not None
+    assert server.engine is not None
+    assert server.overlay is not None
+
+    results = server.engine.process_changes(server.vsm, server.overlay, {source_uri})
+    diags = results.get(source_uri, [])
+
+    z101_diags = [d for d in diags if d.code == "Z101"]
+    assert len(z101_diags) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -2465,7 +2465,7 @@ wheels = [
 
 [[package]]
 name = "zenzic"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-re2" },


### PR DESCRIPTION
## Summary

This PR resolves the deterministic divergence between the CLI and the LSP server (`LSP-FIX-002`) by integrating universal discovery and exclusion gates:

1. **Workspace Initialization Sync**:
   - `initialized` notification handler now triggers `_build_vsm_sync()` followed immediately by `_sync_workspace_and_publish()`.
   - Computes initial DQS score and emits `zenzic/dqsUpdate` immediately upon workspace initialization without requiring a file to be opened.

2. **Exclusion Enforcement (DRY)**:
   - Enforces `LayeredExclusionManager` inside `_is_within_domain` and file processing handlers.
   - Files matching `excluded_dirs` or `excluded_file_patterns` in `.zenzic.toml` (e.g. `docs/tutorials/examples/**`) are dropped silently and emit 0 diagnostics.

3. **Asset Resolution (Z101 Fix)**:
   - `_build_vsm_sync` and `IncrementalAnalysisEngine` full sync now walk and index static asset files (HTML, PNG, SVG, etc.) present under `docs_root`.
   - `_to_canonical_url` strips `.html`/`.htm`/`.mdx`/`.md` extensions contextually.
   - `VSMBrokenLinkRule.check_vsm` restricts `Z103` (ORPHAN_LINK) warnings to Markdown source files only.