### PR TITLE
fix(core): normalize lsp absolute paths for layered exclusion evaluation

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tool.bumpversion]
-current_version = "0.24.4"
+current_version = "0.24.5"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}{pre_l}{pre_n}",

--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Zenzic version
       description: Output of `zenzic --version`
-      placeholder: "0.24.4"
+      placeholder: "0.24.5"
     validations:
       required: true
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 #
 #   repos:
 #     - repo: https://github.com/PythonWoods/zenzic
-#       rev: v0.24.4
+#       rev: v0.24.5
 #       hooks:
 #         - id: zenzic-verify    # quality gate — corrisponde a `just verify` lato zenzic
 #         - id: zenzic-guard     # fast staged-file credential scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [0.24.5] - 2026-07-25
 
+## [0.24.5] - 2026-07-25
+
 ### Fixed
 
 - **Exclusion Path Normalization (`LSP-FIX-008`)**: Hardened the `LayeredExclusionManager` to correctly normalize absolute URIs from the LSP server into repo-relative paths before evaluating `.gitignore` and `.zenzic.toml` exclusion rules. This eradicates false-positive diagnostics on user-excluded directories (e.g., `docs/tutorials/examples`) when opened in VS Code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.24.5] - 2026-07-25
+
+### Fixed
+
+- **Exclusion Path Normalization (`LSP-FIX-008`)**: Hardened the `LayeredExclusionManager` to correctly normalize absolute URIs from the LSP server into repo-relative paths before evaluating `.gitignore` and `.zenzic.toml` exclusion rules. This eradicates false-positive diagnostics on user-excluded directories (e.g., `docs/tutorials/examples`) when opened in VS Code.
+
 ## [0.24.4] - 2026-07-24
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ abstract: >-
   performs deterministic static analysis using a two-pass reference
   pipeline and a RE2-backed credential scanner, with zero subprocess
   calls and full SARIF 2.1.0 support for CI/CD integration.
-version: 0.24.4
-date-released: 2026-07-24
+version: 0.24.5
+date-released: 2026-07-25
 url: "https://zenzic.dev"
 repository-code: "https://github.com/PythonWoods/zenzic"
 repository-artifact: "https://pypi.org/project/zenzic/"

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Zenzic Core is headless and emits standardized **SARIF** (Static Analysis Result
       "tool": {
         "driver": {
           "name": "zenzic",
-          "version": "0.24.4",
+          "version": "0.24.5",
           "rules": [
             {
               "id": "Z101",
@@ -288,7 +288,7 @@ uv tool upgrade zenzic
 To run a specific version ephemerally without altering your global environment:
 
 ```bash
-uvx zenzic@0.24.4 check all
+uvx zenzic@0.24.5 check all
 ```
 
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,9 +8,9 @@
 
 | Field    | Value      |
 | :------- | :--------- |
-| Version  | v0.24.4     |
+| Version  | v0.24.5     |
 | Codename | Magnetite   |
-| Date     | 2026-07-24 |
+| Date     | 2026-07-25 |
 | Status   | Stable |
 
 ## Release Checklist
@@ -21,7 +21,7 @@ Before tagging, every item must be green:
 - [ ] `zenzic lab all` — all 20 scenarios exit with expected code
 - [ ] `zenzic score --stamp` committed — badge in README.md reflects current score
 - [ ] `zenzic check all .` — zero findings in the repo root
-- [ ] `pyproject.toml` version matches the tag (`0.24.4`)
+- [ ] `pyproject.toml` version matches the tag (`0.24.5`)
 - [ ] `CITATION.cff` version and date updated
 - [ ] `CHANGELOG.md` — `[Unreleased]` section moved to the new version heading
 - [ ] Update SECURITY.md support table (Add new release, demote previous to Critical/EOL).
@@ -53,11 +53,11 @@ git checkout main
 git pull origin main
 
 # 3. Tag the main branch and push
-git tag v0.24.4
+git tag v0.24.5
 git push origin main --tags
 ```
 
-- [ ] Create GitHub Release from the tag, using the `## [0.24.4]` CHANGELOG section as the release body.
+- [ ] Create GitHub Release from the tag, using the `## [0.24.5]` CHANGELOG section as the release body.
 
 ## Changelog Reference
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,7 +205,7 @@ extra:
   # ADR-037: No hardcoded SemVer in any .html or .md source.
   # CI pipeline passes the current version at build time, e.g.:
   #   uv run mkdocs build --extra zenzic_version=0.14.1
-  zenzic_version: "0.24.4"  # release sync
+  zenzic_version: "0.24.5"  # release sync
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/PythonWoods/zenzic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zenzic"
-version = "0.24.4"
+version = "0.24.5"
 description = "Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/zenzic/__init__.py
+++ b/src/zenzic/__init__.py
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """Zenzic — engine-agnostic static analyzer and credential scanner for Markdown documentation."""
 
-__version__ = "0.24.4"
+__version__ = "0.24.5"
 __version_name__ = "Basalt"  # Release codename stored separately from the package version.

--- a/src/zenzic/cli/_standalone.py
+++ b/src/zenzic/cli/_standalone.py
@@ -1588,7 +1588,7 @@ version = "0.1.0"
 description = "Custom Zenzic plugin rule package"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["zenzic>=0.24.4"]
+dependencies = ["zenzic>=0.24.5"]
 
 [project.entry-points."zenzic.rules"]
 {project_slug} = "{module_name}.rules:{class_name}"

--- a/src/zenzic/core/exclusion.py
+++ b/src/zenzic/core/exclusion.py
@@ -241,6 +241,24 @@ class LayeredExclusionManager:
         """Return True if a file should be excluded from scanning.
 
         Full 5-layer evaluation for individual files.
+
+        Path normalisation (LSP-FIX-008):
+            The incoming *file_path* may be either an absolute path (from the
+            LSP server, which resolves URIs to ``Path`` objects) or a relative
+            path (from the CLI ``os.walk`` loop).  To guarantee deterministic
+            exclusion results regardless of the caller, a single canonical
+            ``eval_path`` is derived at the L2-VCS / L3-Config boundary:
+
+            1. If *file_path* is absolute and inside ``self._repo_root``, it
+               is made repo-relative — the authoritative form for VCS patterns
+               and full-depth config exclusions.
+            2. Otherwise the docs-relative *rel_path* is used as fallback.
+
+            All L2 VCS and L3 Config path-prefix checks operate on
+            ``eval_str`` (the ``as_posix()`` of ``eval_path``), so patterns
+            such as ``docs/tutorials/examples`` match correctly even when the
+            caller passes an absolute path like
+            ``/repo/docs/tutorials/examples/file.md``.
         """
         filename = file_path.name
         try:
@@ -256,7 +274,7 @@ class LayeredExclusionManager:
         ):
             return True
 
-        # L1: System guardrails — check path components
+        # L1: System guardrails — check path components (docs-relative scope)
         for part in Path(rel_path).parts[:-1]:  # directories only, not filename
             if part in self._system_dirs:
                 return True
@@ -266,27 +284,43 @@ class LayeredExclusionManager:
             if any(p.match(filename) for p in self._config_included_patterns):
                 return False
 
-        # L2 forced: included_dirs
+        # L2 forced: included_dirs (docs-relative scope)
         for part in Path(rel_path).parts[:-1]:
             if part in self._config_included_dirs:
                 return False
 
-        # L4: CLI --exclude-dir (check path components)
+        # L4: CLI --exclude-dir (docs-relative scope)
         for part in Path(rel_path).parts[:-1]:
             if part in self._cli_exclude_dirs:
                 return True
 
-        # L4: CLI --include-dir (check path components)
+        # L4: CLI --include-dir (docs-relative scope)
         for part in Path(rel_path).parts[:-1]:
             if part in self._cli_include_dirs:
                 return False
 
-        # L2 VCS: .gitignore patterns
+        # ── Path normalisation for L2-VCS and L3-Config checks ──────────────
+        # Derive a repo-relative path so that absolute paths delivered by the
+        # LSP server produce the same exclusion result as CLI-relative paths.
+        # Priority: repo-relative > docs-relative > filename-only.
+        try:
+            eval_path = (
+                file_path.relative_to(self._repo_root)
+                if (file_path.is_absolute() and self._repo_root is not None)
+                else Path(rel_path)
+            )
+        except ValueError:
+            # file_path is absolute but outside the repo — fall back to docs-relative
+            eval_path = Path(rel_path)
+
+        eval_str = eval_path.as_posix()
+
+        # L2 VCS: .gitignore patterns (evaluated against repo-relative path)
         if self._vcs_pathspec is not None:
-            if self._vcs_pathspec.match_file(rel_path):
+            if self._vcs_pathspec.match_file(eval_str):
                 return True
 
-        # L3: Config excluded_file_patterns
+        # L3: Config excluded_file_patterns (filename match — path-independent)
         if self._config_excluded_patterns:
             for p, original_str in self._config_excluded_patterns:
                 if p.match(filename):
@@ -294,21 +328,18 @@ class LayeredExclusionManager:
                         self._global_tracker.mark_excluded_file_pattern_used(original_str)
                     return True
 
-        # L3: Config excluded_dirs (check path components against basename)
-        for part in Path(rel_path).parts[:-1]:
+        # L3: Config excluded_dirs — individual component match (e.g. "examples")
+        for part in eval_path.parts[:-1]:
             if part in self._config_excluded_dirs:
                 return True
 
-        # L3: Config excluded_dirs (check full repo-relative paths)
-        if self._repo_root:
-            try:
-                repo_rel = file_path.relative_to(self._repo_root).as_posix()
-                repo_rel_path = Path(repo_rel)
-                for parent in repo_rel_path.parents:
-                    if parent.as_posix() in self._config_excluded_dirs:
-                        return True
-            except ValueError:
-                pass
+        # L3: Config excluded_dirs — full-depth prefix match
+        # Handles patterns like "docs/tutorials/examples" which are repo-relative
+        # and thus never matched by a single-component scan.
+        for i in range(1, len(eval_path.parts)):
+            prefix = "/".join(eval_path.parts[:i])
+            if prefix in self._config_excluded_dirs:
+                return True
 
         # L7: Default — included
         return False

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -1087,3 +1087,117 @@ def test_lsp_enforces_user_excluded_dirs(tmp_path) -> None:
     results = server.engine.process_changes(server.vsm, server.overlay, None)
     diags = results.get(ex_uri, [])
     assert len(diags) == 0
+
+
+def test_lsp_absolute_uri_excluded_path_emits_zero_diagnostics(tmp_path) -> None:
+    """LSP-FIX-008: absolute file:// URI inside an excluded_dirs path must produce 0 diagnostics.
+
+    Regression test for the false-positive bug where the LSP server passed an
+    absolute ``Path`` to ``LayeredExclusionManager.should_exclude_file`` but the
+    method only matched docs-relative path components, causing excluded files to
+    escape the exclusion gate and receive spurious diagnostics.
+
+    Setup:
+        - ``.zenzic.toml`` declares ``excluded_dirs = ["docs/tutorials/examples"]``
+          (repo-relative, full-depth pattern).
+        - ``docs/tutorials/examples/z5xx-content/z506-malformed-frontmatter.md``
+          contains intentionally malformed content that would trigger findings
+          if analysed.
+
+    Acceptance criterion:
+        Opening the file via ``textDocument/didOpen`` with an absolute
+        ``file://`` URI must result in the server dropping the document (domain
+        gate) and publishing exactly **0 diagnostics** for that URI.
+    """
+    import io
+    import json
+
+    # Configure repo with a full-depth exclusion path
+    config_file = tmp_path / ".zenzic.toml"
+    config_file.write_text(
+        'docs_dir = "docs"\n'
+        'excluded_dirs = ["docs/tutorials/examples"]\n'
+    )
+
+    # Create the excluded file tree
+    excluded_dir = tmp_path / "docs" / "tutorials" / "examples" / "z5xx-content"
+    excluded_dir.mkdir(parents=True, exist_ok=True)
+
+    excluded_file = excluded_dir / "z506-malformed-frontmatter.md"
+    excluded_file.write_text(
+        "---\n"
+        "title\n"  # malformed frontmatter — would trigger Z506 if analysed
+        "---\n"
+        "[Broken link](absolutely-missing-target.md)\n"  # would trigger Z101
+    )
+
+    # Also create a valid in-bounds file so docs_root is non-empty
+    docs_dir = tmp_path / "docs"
+    index_md = docs_dir / "index.md"
+    index_md.write_text("# Home\nWelcome.\n")
+
+    def encode_rpc(msg: dict) -> bytes:
+        body = json.dumps(msg, separators=(",", ":")).encode("utf-8")
+        header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+        return header + body
+
+    excluded_uri = excluded_file.resolve().as_uri()
+    workspace_uri = tmp_path.resolve().as_uri()
+
+    req_init = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {"rootUri": workspace_uri},
+    }
+    req_initialized = {"jsonrpc": "2.0", "method": "initialized", "params": {}}
+    req_open = {
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {
+            "textDocument": {
+                "uri": excluded_uri,
+                "text": excluded_file.read_text(encoding="utf-8"),
+            }
+        },
+    }
+    req_exit = {"jsonrpc": "2.0", "method": "exit", "params": {}}
+
+    in_stream = io.BytesIO()
+    in_stream.write(encode_rpc(req_init))
+    in_stream.write(encode_rpc(req_initialized))
+    in_stream.write(encode_rpc(req_open))
+    in_stream.write(encode_rpc(req_exit))
+    in_stream.seek(0)
+
+    out_stream = io.BytesIO()
+    server = LanguageServer(stdin=in_stream, stdout=out_stream)
+    server.serve()
+
+    # Gate 1: domain check must have dropped the document
+    assert excluded_uri not in server.documents.documents, (
+        "Excluded file must be dropped by _is_within_domain before entering DocumentManager"
+    )
+
+    # Gate 2: no diagnostics must have been published for the excluded URI
+    out_stream.seek(0)
+    output = out_stream.read()
+
+    diag_count_for_excluded = 0
+    for part in output.split(b"\r\n\r\n"):
+        if b"publishDiagnostics" not in part:
+            continue
+        body_str = part.split(b"Content-Length")[0]
+        try:
+            resp = json.loads(body_str.decode("utf-8"))
+            if resp.get("method") == "textDocument/publishDiagnostics":
+                if resp["params"]["uri"] == excluded_uri:
+                    diag_count_for_excluded += len(resp["params"]["diagnostics"])
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+    assert diag_count_for_excluded == 0, (
+        f"Expected 0 diagnostics for excluded URI, got {diag_count_for_excluded}. "
+        "LSP-FIX-008 path normalisation regression."
+    )
+

--- a/uv.lock
+++ b/uv.lock
@@ -2465,7 +2465,7 @@ wheels = [
 
 [[package]]
 name = "zenzic"
-version = "0.24.4"
+version = "0.24.5"
 source = { editable = "." }
 dependencies = [
     { name = "google-re2" },


### PR DESCRIPTION


### Fixed
- **Exclusion Path Normalization (`LSP-FIX-008`)**: Hardened the `LayeredExclusionManager` to correctly normalize absolute URIs from the LSP server into repo-relative paths before evaluating `.gitignore` and `.zenzic.toml` exclusion rules. This eradicates false-positive diagnostics on user-excluded directories (e.g., `docs/tutorials/examples`) when opened in VS Code.