### PR TITLE
chore(release): v0.25.1 URP parity and adapter hot-reload

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tool.bumpversion]
-current_version = "0.25.0"
+current_version = "0.25.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}{pre_l}{pre_n}",

--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Zenzic version
       description: Output of `zenzic --version`
-      placeholder: "0.25.0"
+      placeholder: "0.25.1"
     validations:
       required: true
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 #
 #   repos:
 #     - repo: https://github.com/PythonWoods/zenzic
-#       rev: v0.25.0
+#       rev: v0.25.1
 #       hooks:
 #         - id: zenzic-verify    # quality gate — corrisponde a `just verify` lato zenzic
 #         - id: zenzic-guard     # fast staged-file credential scan

--- a/.zenzic.toml
+++ b/.zenzic.toml
@@ -50,7 +50,6 @@ excluded_file_patterns = []
 
 [governance.directory_policies]
 "docs/assets/**" = ["Z405"]
-"docs/blog/**" = ["Z402", "Z101"]
 "docs/favicon.ico" = ["Z405"]
 "docs/blog/rss.xsl" = ["Z405"]
 "docs/tutorials/examples/z1xx-links/**" = ["Z107"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Adapter-Level `material/blog` Plugin Recognition (`LSP-FIX-011`)**: Extended `MkDocsAdapter` to automatically detect the `material/blog` plugin and classify all posts under `<blog_dir>/posts/` as `REACHABLE` routes in the Virtual Site Map (VSM).
+- **Directory Nav Path Resolution (`LSP-FIX-011`)**: Updated `MkDocsAdapter.get_nav_paths()` to expand trailing-slash directory entries (e.g. `blog/`) to their implicit `index.md` target (`blog/index.md`), eliminating false-positive `Z402` (Unlisted Page) findings for plugin index pages.
+
+### Fixed
+
+- **Inline HTML Suppression LSP Parity (`LSP-FIX-011`)**: Updated `IncrementalAnalysisEngine._run_urp_checks()` to pass the active `SuppressionTracker` when evaluating Polyglot Extractor nodes. Suppressed HTML elements (`data-zenzic-ignore`) are now correctly marked as consumed, eliminating spurious `Z603` (Dead Suppression) warnings in editor sessions.
+
+
 ## [0.25.0] - 2026-07-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-07-26
+
 ### Added
 
 - **Adapter-Level `material/blog` Plugin Recognition (`LSP-FIX-011`)**: Extended `MkDocsAdapter` to automatically detect the `material/blog` plugin and classify all posts under `<blog_dir>/posts/` as `REACHABLE` routes in the Virtual Site Map (VSM).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ abstract: >-
   performs deterministic static analysis using a two-pass reference
   pipeline and a RE2-backed credential scanner, with zero subprocess
   calls and full SARIF 2.1.0 support for CI/CD integration.
-version: 0.25.0
-date-released: 2026-07-25
+version: 0.25.1
+date-released: 2026-07-26
 url: "https://zenzic.dev"
 repository-code: "https://github.com/PythonWoods/zenzic"
 repository-artifact: "https://pypi.org/project/zenzic/"

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Zenzic Core is headless and emits standardized **SARIF** JSON, ensuring seamless
       "tool": {
         "driver": {
           "name": "zenzic",
-          "version": "0.25.0",
+          "version": "0.25.1",
           "rules": [
             {
               "id": "Z101",
@@ -215,7 +215,7 @@ uv tool upgrade zenzic
 To run a specific version ephemerally without altering your global environment:
 
 ```bash
-uvx zenzic@0.25.0 check all
+uvx zenzic@0.25.1 check all
 ```
 
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,9 +8,9 @@
 
 | Field    | Value      |
 | :------- | :--------- |
-| Version  | v0.25.0     |
+| Version  | v0.25.1     |
 | Codename | Magnetite   |
-| Date     | 2026-07-25 |
+| Date     | 2026-07-26 |
 | Status   | Stable |
 
 ## Release Checklist
@@ -21,7 +21,7 @@ Before tagging, every item must be green:
 - [ ] `zenzic lab all` — all 20 scenarios exit with expected code
 - [ ] `zenzic score --stamp` committed — badge in README.md reflects current score
 - [ ] `zenzic check all .` — zero findings in the repo root
-- [ ] `pyproject.toml` version matches the tag (`0.25.0`)
+- [ ] `pyproject.toml` version matches the tag (`0.25.1`)
 - [ ] `CITATION.cff` version and date updated
 - [ ] `CHANGELOG.md` — `[Unreleased]` section moved to the new version heading
 - [ ] Update SECURITY.md support table (Add new release, demote previous to Critical/EOL).
@@ -53,12 +53,12 @@ git checkout main
 git pull origin main
 
 # 3. Tag the main branch and push
-git tag -s -S -m "Release v0.25.0" v0.25.0
+git tag -s -S -m "Release v0.25.1" v0.25.1
 git push origin main --tags
 
 ```
 
-- [ ] Create GitHub Release from the tag, using the `## [0.25.0]` CHANGELOG section as the release body.
+- [ ] Create GitHub Release from the tag, using the `## [0.25.1]` CHANGELOG section as the release body.
 
 ## Changelog Reference
 

--- a/docs/blog/posts/2026-07-25-zenzic-v0250-lsp-stabilization.md
+++ b/docs/blog/posts/2026-07-25-zenzic-v0250-lsp-stabilization.md
@@ -1,0 +1,89 @@
+---
+title: "Zenzic v0.25.0: LSP Stabilization & Adapter-Driven Hot-Reloading"
+slug: zenzic-v0250-lsp-stabilization
+date: 2026-07-25
+authors:
+  - pythonwoods
+description: >
+  Zenzic v0.25.0 stabilizes Language Server Protocol (LSP) operations with centralized core governance filtering, adapter-driven configuration hot-reloading, and an updated BaseAdapter contract.
+categories:
+  - Releases
+  - Engineering
+---
+<!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+Zenzic v0.25.0 stabilizes the Language Server Protocol (LSP) integration, guaranteeing strict diagnostic parity between CLI and editor sessions. This release introduces centralized core governance evaluation, adapter-driven configuration hot-reloading for live VSM updates, and an updated `BaseAdapter` contract.
+
+<!-- more -->
+
+## Diagnostic Parity and Centralized Governance
+
+In prior releases, governance evaluation (`directory_policies` and `per_file_ignores`) was executed within the CLI runner pipeline post-scanning. When editing files in LSP mode, incremental single-file analysis paths occasionally bypassed global directory policies, creating diagnostic divergence between terminal runs and VS Code PROBLEMS panels.
+
+Zenzic v0.25.0 eradicates this divergence by centralizing governance evaluation into `zenzic.core.governance`.
+
+### Single-Source-of-Truth Filtering
+
+The `IncrementalAnalysisEngine._analyze_file` pipeline now evaluates governance rules directly at the core engine level:
+
+1. **Incremental Evaluation**: Every document edit evaluated by the LSP engine executes `apply_directory_policies()` and `apply_per_file_ignores()` before diagnostics are emitted.
+2. **Determinism Guaranteed**: Whether a file is inspected via `zenzic check all` in CI or opened inside VS Code, identical findings are suppressed and reported.
+
+---
+
+## Adapter-Driven Config Hot-Reloading (`LSP-FIX-009`)
+
+Documentation architecture configurations (`mkdocs.yml`, `zensical.toml`) evolve during development. Previously, modifying navigation structures or plugin settings in `mkdocs.yml` required restarting the Zenzic Language Server to rebuild the Virtual Site Map (VSM).
+
+v0.25.0 introduces dynamic adapter-driven configuration watching to eliminate manual server restarts.
+
+### Reactive VSM Synchronization
+
+The LSP file watcher now queries active adapters for watched configuration targets:
+
+- **Adapter Sovereignty**: The core engine does not hardcode configuration filenames. Each adapter declares its configuration dependencies via the `watched_config_files` contract property.
+- **Hot-Reload Dispatch**: When `mkdocs.yml` or `mkdocs.yaml` is modified, the LSP server intercepts the change, invalidates cached route entries, and triggers an in-memory VSM rebuild across the entire workspace.
+- **Zero-Latency Navigation Updates**: Re-indexed routes and navigational changes reflect in editor diagnostics immediately upon saving configuration changes.
+
+---
+
+## Breaking Change: `BaseAdapter` Contract Expansion
+
+> [!WARNING]
+> **Breaking Change for Third-Party Adapters**: `BaseAdapter` has been extended under **ADR-078-STRICT** to declare `@property watched_config_files`.
+
+To support framework-agnostic configuration hot-reloading, the base adapter contract (`zenzic.core.adapters._base.BaseAdapter`) introduces a new property requirement:
+
+```python
+class BaseAdapter(ABC):
+    # ...
+    @property
+    def watched_config_files(self) -> frozenset[str]:
+        """Return the configuration filenames that trigger a VSM rebuild in LSP mode."""
+        return frozenset()
+```
+
+### Migration Guide for Adapter Implementers
+
+If you maintain a custom third-party adapter subclassing `BaseAdapter`:
+
+1. Update your class definition to override `watched_config_files`:
+   ```python
+   @property
+   def watched_config_files(self) -> frozenset[str]:
+       return frozenset({"my-framework.config.json"})
+   ```
+2. First-party adapters (`MkDocsAdapter`, `ZensicalAdapter`) have been updated natively.
+
+---
+
+## Upgrading
+
+To update Zenzic Core globally via `uv`:
+
+```bash
+uv tool install --force zenzic
+```
+
+The Zenzic VS Code extension updates automatically via the Visual Studio Marketplace.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -224,7 +224,7 @@ extra:
   # ADR-037: No hardcoded SemVer in any .html or .md source.
   # CI pipeline passes the current version at build time, e.g.:
   #   uv run mkdocs build --extra zenzic_version=0.14.1
-  zenzic_version: "0.25.0"  # release sync
+  zenzic_version: "0.25.1"  # release sync
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/PythonWoods/zenzic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zenzic"
-version = "0.25.0"
+version = "0.25.1"
 description = "Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/zenzic/__init__.py
+++ b/src/zenzic/__init__.py
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """Zenzic — engine-agnostic static analyzer and credential scanner for Markdown documentation."""
 
-__version__ = "0.25.0"
+__version__ = "0.25.1"
 __version_name__ = "Basalt"  # Release codename stored separately from the package version.

--- a/src/zenzic/cli/_standalone.py
+++ b/src/zenzic/cli/_standalone.py
@@ -1588,7 +1588,7 @@ version = "0.1.0"
 description = "Custom Zenzic plugin rule package"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["zenzic>=0.25.0"]
+dependencies = ["zenzic>=0.25.1"]
 
 [project.entry-points."zenzic.rules"]
 {project_slug} = "{module_name}.rules:{class_name}"

--- a/src/zenzic/core/adapters/_mkdocs.py
+++ b/src/zenzic/core/adapters/_mkdocs.py
@@ -350,6 +350,35 @@ def _extract_i18n_fallback_to_default(doc_config: dict[str, Any]) -> bool:
     return True
 
 
+def _extract_blog_dir(doc_config: dict[str, Any]) -> str | None:
+    """Return the blog posts prefix when the ``material/blog`` plugin is active.
+
+    The ``material/blog`` plugin (``mkdocs-material``) dynamically generates
+    all routes under ``<blog_dir>/posts/`` at build time — these files are
+    **never** listed in the static ``nav:`` section of ``mkdocs.yml``.  The
+    MkDocs adapter must treat them as ``REACHABLE`` rather than
+    ``ORPHAN_BUT_EXISTING``; otherwise Zenzic raises Z103 for every internal
+    link that targets a blog post.
+
+    Args:
+        doc_config: Parsed ``mkdocs.yml`` config dict.
+
+    Returns:
+        The relative ``<blog_dir>/posts/`` prefix (e.g. ``"blog/posts"``) when
+        the blog plugin is active; ``None`` when the plugin is absent.
+    """
+    for name, blog_cfg in _iter_plugins(doc_config):
+        # Accept both short form ``blog`` and fully-qualified ``material/blog``.
+        if name not in ("blog", "material/blog"):
+            continue
+        blog_dir = blog_cfg.get("blog_dir", "blog") if isinstance(blog_cfg, dict) else "blog"
+        # Normalise: strip leading/trailing slashes so the prefix is always
+        # a plain relative posix string like "blog/posts".
+        blog_dir = blog_dir.strip("/")
+        return f"{blog_dir}/posts"
+    return None
+
+
 def _validate_i18n_fallback_config(doc_config: dict[str, Any]) -> None:
     """Raise ConfigurationError when fallback_to_default is true but no default locale exists.
 
@@ -473,6 +502,12 @@ class MkDocsAdapter(BaseAdapter):
         # must treat locale index pages as REACHABLE without nav evidence.
         self._reconfigure_material: bool = _extract_i18n_reconfigure_material(self._doc_config)
 
+        # When the material/blog plugin is active, every .md file under
+        # <blog_dir>/posts/ is a live, published route generated dynamically by
+        # the plugin — not a static nav entry.  Store the posts prefix so that
+        # _classify_route() can recognise and mark them REACHABLE.
+        self._blog_posts_prefix: str | None = _extract_blog_dir(self._doc_config)
+
         # Emit a UX hint when the config is redundant: reconfigure_material
         # auto-generates the switcher, so extra.alternate is both unnecessary
         # and harmful (it competes with the plugin and can hide the switcher).
@@ -575,10 +610,25 @@ class MkDocsAdapter(BaseAdapter):
         return _extract_i18n_locale_patterns(self._doc_config)
 
     def get_nav_paths(self) -> frozenset[str]:
-        """Return ``.md`` paths listed in the nav, relative to ``docs_root``."""
+        """Return ``.md`` paths listed in the nav, relative to ``docs_root``.
+
+        MkDocs resolves directory nav entries (e.g. ``blog/``) to their
+        implicit ``index.md`` (e.g. ``blog/index.md``) at build time.  We
+        mirror that resolution here so that plugin-managed index pages such as
+        ``blog/index.md`` are correctly classified as ``REACHABLE`` instead of
+        ``ORPHAN_BUT_EXISTING``.
+        """
         raw: set[str] = set()
         _collect_nav_paths(self._doc_config.get("nav"), raw)
-        return frozenset(p.lstrip("/") for p in raw if p.endswith(".md"))
+        nav_paths: set[str] = set()
+        for p in raw:
+            p = p.lstrip("/")
+            if p.endswith(".md"):
+                nav_paths.add(p)
+            elif p.endswith("/"):
+                # MkDocs resolves 'section/' → 'section/index.md' automatically.
+                nav_paths.add(f"{p}index.md")
+        return frozenset(nav_paths)
 
     def has_engine_config(self) -> bool:
         """``True`` when ``mkdocs.yml`` was found on disk **or** locales were declared.
@@ -657,6 +707,10 @@ class MkDocsAdapter(BaseAdapter):
            This check fires only when rules 0-2 have not already resolved the
            status, so an explicit nav entry for ``it/index.md`` is never
            overridden.
+        3b. ``material/blog`` plugin active and file is under ``<blog_dir>/posts/``
+            → ``REACHABLE``.  Blog posts are dynamically indexed by the plugin and
+            are never listed in the static ``nav:``; they are published, reachable
+            pages and must not be classified as orphans.
         4. Otherwise → ``ORPHAN_BUT_EXISTING``.
 
         Args:
@@ -696,6 +750,11 @@ class MkDocsAdapter(BaseAdapter):
             parts = rel.parts
             if len(parts) == 2 and parts[0] in self._locale_dirs:  # e.g. it/index.md
                 return "REACHABLE"
+
+        # material/blog plugin: every .md under <blog_dir>/posts/ is a live,
+        # dynamically-indexed page — never listed in nav: but always REACHABLE.
+        if self._blog_posts_prefix and rel_posix.startswith(f"{self._blog_posts_prefix}/"):
+            return "REACHABLE"
 
         return "ORPHAN_BUT_EXISTING"
 

--- a/src/zenzic/core/incremental.py
+++ b/src/zenzic/core/incremental.py
@@ -457,7 +457,7 @@ class IncrementalAnalysisEngine:
             )
 
         # URP Checks
-        findings.extend(self._run_urp_checks(vsm, path, text))
+        findings.extend(self._run_urp_checks(vsm, path, text, tracker=tracker))
 
         # Dead suppression detection
         findings.extend(tracker.get_dead_suppressions())
@@ -532,6 +532,7 @@ class IncrementalAnalysisEngine:
         vsm: VirtualSiteMap,
         path: Path,
         text: str,
+        tracker: SuppressionTracker | None = None,
     ) -> list[RuleFinding]:
         """Run the Uniform Resolver Pipeline checks on a single file.
 
@@ -541,6 +542,13 @@ class IncrementalAnalysisEngine:
             vsm: The active Virtual Site Map instance.
             path: Resolved absolute path of the file.
             text: Raw Markdown content.
+            tracker: Active :class:`~zenzic.core.suppressions.SuppressionTracker`
+                for this file.  When provided and a Polyglot Extractor node has
+                ``node.suppressed = True``, the corresponding
+                ``DATA-ZENZIC-IGNORE`` directive is marked ``consumed`` so that
+                :meth:`~zenzic.core.suppressions.SuppressionTracker.get_dead_suppressions`
+                does not emit Z603 for an inline suppression that correctly
+                silenced a URP finding (parity with ``validator.py`` CLI path).
 
         Returns:
             List of ``RuleFinding`` instances.
@@ -633,6 +641,17 @@ class IncrementalAnalysisEngine:
                         match_text=node.raw_tag,
                     )
                 )
+
+            # Mirror validator.py lines 1391-1400: when data-zenzic-ignore is
+            # present on the node, the CLI marks the corresponding directive as
+            # consumed so that get_dead_suppressions() does not fire Z603.
+            # Without this branch the LSP would emit Z603 for every suppressed
+            # HTML node because the directive is never consumed here.
+            if node.suppressed and tracker is not None:
+                for d in tracker.directives:
+                    if d.line_no == node.line_no and d.code == "DATA-ZENZIC-IGNORE":
+                        d.consumed = True
+                        break
 
         # Markdown Links
         local_anchors = self.anchors_cache.get(path, set())

--- a/uv.lock
+++ b/uv.lock
@@ -2465,7 +2465,7 @@ wheels = [
 
 [[package]]
 name = "zenzic"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-re2" },


### PR DESCRIPTION
## Objective
Deploy patch release `0.25.1` to eradicate deterministic divergence between CLI and LSP by resolving Z103/Z603 false positives, and to publish the release announcement for `v0.25.0`.

## Architectural Changes
- **URP & Adapter Parity (`LSP-FIX-011`)**: 
  - Upgraded `MkDocsAdapter` to natively recognize the `material/blog` plugin. Blog posts are now correctly classified as `REACHABLE` in the Virtual Site Map (VSM), eliminating false-positive `Z103` (Orphan Link) diagnostics in VS Code.
  - Hardened `_run_urp_checks` in the LSP incremental engine to explicitly mark `DATA-ZENZIC-IGNORE` directives as consumed, mirroring CLI behavior and eliminating false-positive `Z603` (Dead Suppression) diagnostics.
- **Documentation**: Drafted the official release announcement blog post for `v0.25.0` (LSP Stabilization & Hot-Reloading).

## Verification
- `uv run zenzic check all --strict` passed (DQS 98/100) with the `docs/blog/**` directory policy completely removed from `.zenzic.toml`.
- `pytest` suite passed (1484/1484).