### PR TITLE
fix(security): v0.25.2 Z202 path traversal bypass in LSP engine

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tool.bumpversion]
-current_version = "0.25.1"
+current_version = "0.25.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}{pre_l}{pre_n}",

--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Zenzic version
       description: Output of `zenzic --version`
-      placeholder: "0.25.1"
+      placeholder: "0.25.2"
     validations:
       required: true
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 #
 #   repos:
 #     - repo: https://github.com/PythonWoods/zenzic
-#       rev: v0.25.1
+#       rev: v0.25.2
 #       hooks:
 #         - id: zenzic-verify    # quality gate — corrisponde a `just verify` lato zenzic
 #         - id: zenzic-guard     # fast staged-file credential scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Path Traversal Security Parity (`LSP-FIX-012`)**: Hardened `Z202`/`Z203` path traversal evaluation in `IncrementalAnalysisEngine._run_urp_checks()` by replacing absolute OS filesystem depth checks (`len(path.parents)`) with `docs_root`-boundary escape detection (`os.path.normpath` + `is_relative_to(resolved_docs_root)`). This guarantees 100% security parity between CLI and LSP mode.
+
+
 ## [0.25.1] - 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.25.2] - 2026-07-26
+
 ### Fixed
 
 - **Path Traversal Security Parity (`LSP-FIX-012`)**: Hardened `Z202`/`Z203` path traversal evaluation in `IncrementalAnalysisEngine._run_urp_checks()` by replacing absolute OS filesystem depth checks (`len(path.parents)`) with `docs_root`-boundary escape detection (`os.path.normpath` + `is_relative_to(resolved_docs_root)`). This guarantees 100% security parity between CLI and LSP mode.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ abstract: >-
   performs deterministic static analysis using a two-pass reference
   pipeline and a RE2-backed credential scanner, with zero subprocess
   calls and full SARIF 2.1.0 support for CI/CD integration.
-version: 0.25.1
+version: 0.25.2
 date-released: 2026-07-26
 url: "https://zenzic.dev"
 repository-code: "https://github.com/PythonWoods/zenzic"

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Zenzic Core is headless and emits standardized **SARIF** JSON, ensuring seamless
       "tool": {
         "driver": {
           "name": "zenzic",
-          "version": "0.25.1",
+          "version": "0.25.2",
           "rules": [
             {
               "id": "Z101",
@@ -215,7 +215,7 @@ uv tool upgrade zenzic
 To run a specific version ephemerally without altering your global environment:
 
 ```bash
-uvx zenzic@0.25.1 check all
+uvx zenzic@0.25.2 check all
 ```
 
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@
 
 | Field    | Value      |
 | :------- | :--------- |
-| Version  | v0.25.1     |
+| Version  | v0.25.2     |
 | Codename | Magnetite   |
 | Date     | 2026-07-26 |
 | Status   | Stable |
@@ -21,7 +21,7 @@ Before tagging, every item must be green:
 - [ ] `zenzic lab all` — all 20 scenarios exit with expected code
 - [ ] `zenzic score --stamp` committed — badge in README.md reflects current score
 - [ ] `zenzic check all .` — zero findings in the repo root
-- [ ] `pyproject.toml` version matches the tag (`0.25.1`)
+- [ ] `pyproject.toml` version matches the tag (`0.25.2`)
 - [ ] `CITATION.cff` version and date updated
 - [ ] `CHANGELOG.md` — `[Unreleased]` section moved to the new version heading
 - [ ] Update SECURITY.md support table (Add new release, demote previous to Critical/EOL).
@@ -53,12 +53,12 @@ git checkout main
 git pull origin main
 
 # 3. Tag the main branch and push
-git tag -s -S -m "Release v0.25.1" v0.25.1
+git tag -s -S -m "Release v0.25.2" v0.25.2
 git push origin main --tags
 
 ```
 
-- [ ] Create GitHub Release from the tag, using the `## [0.25.1]` CHANGELOG section as the release body.
+- [ ] Create GitHub Release from the tag, using the `## [0.25.2]` CHANGELOG section as the release body.
 
 ## Changelog Reference
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -224,7 +224,7 @@ extra:
   # ADR-037: No hardcoded SemVer in any .html or .md source.
   # CI pipeline passes the current version at build time, e.g.:
   #   uv run mkdocs build --extra zenzic_version=0.14.1
-  zenzic_version: "0.25.1"  # release sync
+  zenzic_version: "0.25.2"  # release sync
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/PythonWoods/zenzic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zenzic"
-version = "0.25.1"
+version = "0.25.2"
 description = "Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/zenzic/__init__.py
+++ b/src/zenzic/__init__.py
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """Zenzic — engine-agnostic static analyzer and credential scanner for Markdown documentation."""
 
-__version__ = "0.25.1"
+__version__ = "0.25.2"
 __version_name__ = "Basalt"  # Release codename stored separately from the package version.

--- a/src/zenzic/cli/_standalone.py
+++ b/src/zenzic/cli/_standalone.py
@@ -1588,7 +1588,7 @@ version = "0.1.0"
 description = "Custom Zenzic plugin rule package"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["zenzic>=0.25.1"]
+dependencies = ["zenzic>=0.25.2"]
 
 [project.entry-points."zenzic.rules"]
 {project_slug} = "{module_name}.rules:{class_name}"

--- a/src/zenzic/core/incremental.py
+++ b/src/zenzic/core/incremental.py
@@ -672,20 +672,39 @@ class IncrementalAnalysisEngine:
 
             parsed = urlsplit(url)
 
-            # Z202 / Z203
-            if "../" in url and url.count("../") > len(path.parents):
-                _intent = _classify_traversal_intent(url)
-                findings.append(
-                    RuleFinding(
-                        path,
-                        lineno,
-                        "Z203" if _intent == "suspicious" else "Z202",
-                        f"Path traversal escape detected: '{url}'",
-                        severity="error",
-                        matched_line=raw_line,
+            # Z202 / Z203 — Path Traversal Detection
+            if "../" in url:
+                try:
+                    resolved_docs_root = self.docs_root.resolve()
+                    source_dir = path.parent.resolve()
+                    target_str = os.path.normpath(str(source_dir / parsed.path))
+                    target_path = Path(target_str)
+                    if not target_path.is_relative_to(resolved_docs_root):
+                        _intent = _classify_traversal_intent(url)
+                        findings.append(
+                            RuleFinding(
+                                path,
+                                lineno,
+                                "Z203" if _intent == "suspicious" else "Z202",
+                                f"Path traversal escape detected: '{url}'",
+                                severity="error",
+                                matched_line=raw_line,
+                            )
+                        )
+                        continue
+                except Exception:
+                    _intent = _classify_traversal_intent(url)
+                    findings.append(
+                        RuleFinding(
+                            path,
+                            lineno,
+                            "Z203" if _intent == "suspicious" else "Z202",
+                            f"Path traversal escape detected: '{url}'",
+                            severity="error",
+                            matched_line=raw_line,
+                        )
                     )
-                )
-                continue
+                    continue
 
             # Z105 / Z203
             elif parsed.path.startswith("/"):

--- a/uv.lock
+++ b/uv.lock
@@ -2465,7 +2465,7 @@ wheels = [
 
 [[package]]
 name = "zenzic"
-version = "0.25.1"
+version = "0.25.2"
 source = { editable = "." }
 dependencies = [
     { name = "google-re2" },


### PR DESCRIPTION
## Objective
Deploy security patch `0.25.2` to eradicate a critical Z202/Z203 (Path Traversal) bypass vulnerability in the LSP incremental analysis engine.

## Architectural Changes
- **Z202 Security Parity (`LSP-FIX-012`)**: Replaced a flawed OS-root depth check (`url.count("../") > len(path.parents)`) with deterministic `docs_root` boundary escape detection. The engine now uses `os.path.normpath` and `is_relative_to(resolved_docs_root)` to mathematically guarantee that any relative link escaping the configured documentation root triggers a non-suppressible Z202/Z203 security finding. This restores 100% security parity between the CLI and the VS Code extension.

## Verification
- Simulated LSP traversal (`../../etc/passwd`) correctly triggers Z203.
- `uv run zenzic check all --strict` passed (DQS 98/100).
- `pytest` suite passed.