### PR TITLE
fix(lsp): v0.25.4 severity parity and deterministic UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **LSP DQS Determinism & Severity Parity (`LSP-FIX-014`)**: Deprecated misleading DQS Status Bar notification emission in `server.py` to preserve the Determinism invariant between incremental LSP mode (which observes topological findings only) and CLI batch mode. Filtered `INFO`-level findings (e.g. Z106) at the transport boundary in `incremental.py` to prevent PROBLEMS panel pollution.
+
 ## [0.25.3] - 2026-07-26
 
 ### Added

--- a/src/zenzic/core/incremental.py
+++ b/src/zenzic/core/incremental.py
@@ -494,6 +494,13 @@ class IncrementalAnalysisEngine:
         typed_diags: list[ZenzicDiagnostic] = []
 
         for f in findings:
+            # Severity parity (LSP-FIX-014): drop INFO-level findings at the
+            # transport boundary.  INFO findings (e.g. Z106 non-HTTP scheme hints)
+            # carry no actionable remediation and would flood the VS Code PROBLEMS
+            # panel with noise.  The authoritative record of INFO findings is the
+            # CLI report; the LSP surface is reserved for errors and warnings only.
+            if getattr(f, "severity", "error") == "info":
+                continue
             line_no = max(0, f.line_no - 1)
             matched_line = lines[line_no] if 0 <= line_no < len(lines) else ""
 

--- a/src/zenzic/lsp/server.py
+++ b/src/zenzic/lsp/server.py
@@ -548,27 +548,13 @@ class LanguageServer:
                 }
             )
 
-        # Calculate global DQS from VSM state and emit zenzic/dqsUpdate notification
-        findings_counts: dict[str, int] = {}
-        for route in self.vsm.values():
-            for diag in route.diagnostics:
-                findings_counts[diag.code] = findings_counts.get(diag.code, 0) + 1
-
-        from zenzic.core.scorer import compute_score
-
-        score_report = compute_score(findings_counts)
-
-        self.send_message(
-            {
-                "jsonrpc": "2.0",
-                "method": "zenzic/dqsUpdate",
-                "params": {
-                    "score": score_report.score,
-                    "base_score": 100,
-                    "penalties": 100 - score_report.score,
-                },
-            }
-        )
+        # DQS emission intentionally removed (LSP-FIX-014).
+        # The LSP operates in incremental mode and only sees topological findings
+        # (Z1xx/Z4xx). Content findings (Z5xx) on closed files are never analysed,
+        # so any DQS computed here would be non-deterministically lower than the
+        # CLI batch score. Emitting a misleading score violates the Determinism
+        # invariant. The authoritative DQS is produced exclusively by the CLI
+        # (`zenzic check all --strict`) in CI/CD batch mode.
 
     def _handle_hover(self, params: dict[str, Any], msg_id: int | str | None) -> None:
         if msg_id is None or self.vsm is None or not self.repo_root or not self.config:

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -869,7 +869,15 @@ def test_lsp_code_action_unfixable(tmp_path) -> None:
 
 
 def test_lsp_dqs_update_notification(tmp_path) -> None:
-    """Verify _sync_workspace_and_publish emits zenzic/dqsUpdate custom LSP notification."""
+    """Verify _sync_workspace_and_publish does NOT emit zenzic/dqsUpdate (LSP-FIX-014).
+
+    The LSP operates in incremental mode and only observes topological findings
+    (Z1xx/Z4xx).  Content findings (Z5xx) on closed files are never analysed,
+    so any DQS computed here would be non-deterministically lower than the CLI
+    batch score.  Emitting a misleading score violates the Determinism invariant;
+    the notification is therefore intentionally suppressed (LSP-FIX-014).
+    The authoritative DQS is produced exclusively by `zenzic check all --strict`.
+    """
     docs_dir = tmp_path / "docs"
     docs_dir.mkdir(parents=True, exist_ok=True)
     in_bounds_md = docs_dir / "index.md"
@@ -886,24 +894,9 @@ def test_lsp_dqs_update_notification(tmp_path) -> None:
 
     out_stream.seek(0)
     raw_output = out_stream.read().decode("utf-8")
-    assert "zenzic/dqsUpdate" in raw_output
 
-    # Find the zenzic/dqsUpdate message
-    dqs_msg = None
-    for chunk in raw_output.split("\r\n\r\n"):
-        if "zenzic/dqsUpdate" in chunk:
-            lines = chunk.strip().splitlines()
-            for line_str in lines:
-                if line_str.startswith("{"):
-                    dqs_msg = json.loads(line_str)
-                    break
-
-    assert dqs_msg is not None
-    assert dqs_msg["method"] == "zenzic/dqsUpdate"
-    assert "score" in dqs_msg["params"]
-    assert "base_score" in dqs_msg["params"]
-    assert "penalties" in dqs_msg["params"]
-    assert dqs_msg["params"]["base_score"] == 100
+    # Determinism invariant: the misleading partial DQS notification must NOT be emitted.
+    assert "zenzic/dqsUpdate" not in raw_output
 
 
 def test_lsp_relative_link_normalization_no_z101(tmp_path) -> None:
@@ -947,8 +940,15 @@ def test_lsp_relative_link_normalization_no_z101(tmp_path) -> None:
     assert len(z101_diags) == 0
 
 
-def test_lsp_workspace_initialization_emits_initial_dqs(tmp_path) -> None:
-    """Verify that initialized handler triggers workspace sync and emits initial DQS update without opening files."""
+def test_lsp_workspace_initialization_does_not_emit_dqs(tmp_path) -> None:
+    """Verify that the initialized handler triggers workspace sync but does NOT emit DQS (LSP-FIX-014).
+
+    The LSP computes DQS only from in-memory VSM topological findings (Z1xx/Z4xx).
+    Content findings (Z5xx) on closed files are excluded, making the score
+    non-deterministically lower than the CLI batch score.  Displaying a misleading
+    score violates the Determinism invariant.  The authoritative DQS is produced
+    exclusively by `zenzic check all --strict` in CI/CD batch mode.
+    """
     docs_dir = tmp_path / "docs"
     docs_dir.mkdir()
     index_md = docs_dir / "index.md"
@@ -972,7 +972,9 @@ def test_lsp_workspace_initialization_emits_initial_dqs(tmp_path) -> None:
     stdout.seek(0)
     raw_output = stdout.read().decode("utf-8")
 
-    assert "zenzic/dqsUpdate" in raw_output
+    # Determinism invariant: the misleading partial DQS notification must NOT be emitted.
+    assert "zenzic/dqsUpdate" not in raw_output
+    # Workspace state must still be correctly initialised.
     assert server.vsm is not None
     assert server.engine is not None
 


### PR DESCRIPTION
## Objective
Deploy patch release `0.25.4` to enforce strict Severity Parity between the CLI and the LSP server, and to eradicate deterministic divergence by deprecating misleading partial metrics in the IDE.

## Architectural Changes
- **Severity Parity (`LSP-FIX-013`)**: Added a strict filter in the LSP incremental engine (`_findings_to_diagnostics`) to drop findings with `Severity.INFO` (e.g., Z106). This aligns the LSP's default visibility threshold with the CLI, eliminating non-actionable noise in the VS Code PROBLEMS panel.
- **Deterministic UX (`LSP-FIX-014`)**: Removed the partial, in-memory DQS calculation and the `zenzic/dqsUpdate` JSON-RPC notification from the LSP server. Because the LSP operates incrementally (only analyzing opened/modified files for AST rules), its DQS calculation mathematically diverged from the CLI's global batch analysis. Removing this misleading metric restores the Single Source of Truth invariant.

## Verification
- `uv run zenzic check all --strict` passed (DQS 98/100).
- `pytest` suite passed (1484/1484).
- Verified that `INFO` findings no longer pollute the LSP output.