### PR TITLE
chore(release): bump version to 0.26.3

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tool.bumpversion]
-current_version = "0.26.2"
+current_version = "0.26.3"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<pre_l>a|b|rc)(?P<pre_n>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}{pre_l}{pre_n}",

--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Zenzic version
       description: Output of `zenzic --version`
-      placeholder: "0.26.2"
+      placeholder: "0.26.3"
     validations:
       required: true
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 #
 #   repos:
 #     - repo: https://github.com/PythonWoods/zenzic
-#       rev: v0.26.2
+#       rev: v0.26.3
 #       hooks:
 #         - id: zenzic-verify    # quality gate — corrisponde a `just verify` lato zenzic
 #         - id: zenzic-guard     # fast staged-file credential scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.26.3] - 2026-07-28
+
 ### Added
 
 - **Suppression Code Actions (`LSP-FEAT-003`)**: The LSP server now dynamically generates "Suppress this finding" Code Actions for all suppressible diagnostics. Clicking the action automatically injects the correct `<!-- zenzic:ignore:ZXXX -->` comment above the offending line. This feature is strictly disabled for `NON_SUPPRESSIBLE_CODES` (Z2xx Security findings) to enforce the security gate.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ abstract: >-
   performs deterministic static analysis using a two-pass reference
   pipeline and a RE2-backed credential scanner, with zero subprocess
   calls and full SARIF 2.1.0 support for CI/CD integration.
-version: 0.26.2
+version: 0.26.3
 date-released: 2026-07-28
 url: "https://zenzic.dev"
 repository-code: "https://github.com/PythonWoods/zenzic"

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Zenzic Core is headless and emits standardized **SARIF** JSON, ensuring seamless
       "tool": {
         "driver": {
           "name": "zenzic",
-          "version": "0.26.2",
+          "version": "0.26.3",
           "rules": [
             {
               "id": "Z101",
@@ -215,7 +215,7 @@ uv tool upgrade zenzic
 To run a specific version ephemerally without altering your global environment:
 
 ```bash
-uvx zenzic@0.26.2 check all
+uvx zenzic@0.26.3 check all
 ```
 
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@
 
 | Field    | Value      |
 | :------- | :--------- |
-| Version  | v0.26.2     |
+| Version  | v0.26.3     |
 | Codename | Magnetite   |
 | Date     | 2026-07-28 |
 | Status   | Stable |
@@ -21,7 +21,7 @@ Before tagging, every item must be green:
 - [ ] `zenzic lab all` — all 20 scenarios exit with expected code
 - [ ] `zenzic score --stamp` committed — badge in README.md reflects current score
 - [ ] `zenzic check all .` — zero findings in the repo root
-- [ ] `pyproject.toml` version matches the tag (`0.26.2`)
+- [ ] `pyproject.toml` version matches the tag (`0.26.3`)
 - [ ] `CITATION.cff` version and date updated
 - [ ] `CHANGELOG.md` — `[Unreleased]` section moved to the new version heading
 - [ ] Update SECURITY.md support table (Add new release, demote previous to Critical/EOL).
@@ -53,12 +53,12 @@ git checkout main
 git pull origin main
 
 # 3. Tag the main branch and push
-git tag -s -m "Release v0.26.2" v0.26.2
+git tag -s -m "Release v0.26.3" v0.26.3
 git push origin main --tags
 
 ```
 
-- [ ] Create GitHub Release from the tag, using the `## [0.26.2]` CHANGELOG section as the release body.
+- [ ] Create GitHub Release from the tag, using the `## [0.26.3]` CHANGELOG section as the release body.
 
 ## Changelog Reference
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -224,7 +224,7 @@ extra:
   # ADR-037: No hardcoded SemVer in any .html or .md source.
   # CI pipeline passes the current version at build time, e.g.:
   #   uv run mkdocs build --extra zenzic_version=0.14.1
-  zenzic_version: "0.26.2"  # release sync
+  zenzic_version: "0.26.3"  # release sync
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/PythonWoods/zenzic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zenzic"
-version = "0.26.2"
+version = "0.26.3"
 description = "Deterministic Document Integrity Engine and SAST for Markdown/MDX graphs."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/zenzic/__init__.py
+++ b/src/zenzic/__init__.py
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 """Zenzic — engine-agnostic static analyzer and credential scanner for Markdown documentation."""
 
-__version__ = "0.26.2"
+__version__ = "0.26.3"
 __version_name__ = "Basalt"  # Release codename stored separately from the package version.

--- a/src/zenzic/cli/_standalone.py
+++ b/src/zenzic/cli/_standalone.py
@@ -1603,7 +1603,7 @@ version = "0.1.0"
 description = "Custom Zenzic plugin rule package"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["zenzic>=0.26.2"]
+dependencies = ["zenzic>=0.26.3"]
 
 [project.entry-points."zenzic.rules"]
 {project_slug} = "{module_name}.rules:{class_name}"

--- a/uv.lock
+++ b/uv.lock
@@ -2465,7 +2465,7 @@ wheels = [
 
 [[package]]
 name = "zenzic"
-version = "0.26.2"
+version = "0.26.3"
 source = { editable = "." }
 dependencies = [
     { name = "google-re2" },


### PR DESCRIPTION
* Updated `CHANGELOG.md` to add the `0.26.3` release section with a description of the new suppression code actions feature.