### PR TITLE
fix(core): enforce Path Sovereignty boundary and fix AST comment line…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - **Mirror Law Parity (`ADR-020`)**: Authored rule specification cards `docs/rules/Z610.md` and `docs/rules/Z611.md`. Registered both codes in `docs/reference/finding-codes.md` and `mkdocs.yml` navigation tree.
 - **CHANGELOG Archive**: Moved `v0.27.x` release notes to `changelogs/v0.27.x.md` and reset `CHANGELOG.md` for the `v0.28.x` development cycle.
 
+### Fixed
+
+- **Path Sovereignty Guard (`Z202`)**: Enforced strict Path Sovereignty boundary checks in `walk_files` (`src/zenzic/core/discovery.py`) using `path.resolve(strict=False).is_relative_to(resolved_repo_root)`. Symlinks resolving outside the workspace root boundary are safely skipped with a `Z202 Path Traversal` warning. Legitimate internal symlinks inside the workspace root are preserved and scanned normally.
+- **AST Line-Offset Determinism**: Updated `_mask_comments` in `PolyglotExtractor` (`src/zenzic/core/validator.py`) to replace non-newline characters in HTML/MDX comments with spaces while retaining `\n` linebreaks. Prevents line collapse in multiline comments and preserves exact line offsets in AST link diagnostics.
+
 ### Changed
 
 - **Brand & Positioning Alignment (`V0.27-13`)**: Realigned product positioning across package descriptions (`pyproject.toml`), READMEs, documentation, landing page components, and social assets to accurately reflect Zenzic as a **Deterministic Document Integrity Engine**. Eradicated misleading "SAST" terminology from all user-facing surfaces (**Mirror Law ADR-020**).

--- a/src/zenzic/core/discovery.py
+++ b/src/zenzic/core/discovery.py
@@ -92,7 +92,12 @@ def walk_files(
         exclusions (URL mapping, Z402, Z502) happen at the logical layer
         inside the adapter and rule engine.
     """
-    repo_root = getattr(exclusion_manager, "_repo_root", None)
+    repo_root = getattr(exclusion_manager, "_repo_root", None) or root
+    resolved_repo_root = repo_root.resolve(strict=False)
+    import logging
+
+    logger = logging.getLogger("zenzic.core.discovery")
+
     for dirpath, dirnames, filenames in os.walk(root):
         filtered_dirnames = []
         for d in dirnames:
@@ -113,7 +118,26 @@ def walk_files(
             filtered_dirnames.append(d)
         dirnames[:] = sorted(filtered_dirnames)
         for fname in sorted(filenames):
-            yield Path(dirpath) / fname
+            fpath = Path(dirpath) / fname
+            # Security boundary check (Path Sovereignty / Z202 Path Traversal):
+            resolved_fpath = fpath.resolve(strict=False)
+            try:
+                if not resolved_fpath.is_relative_to(resolved_repo_root):
+                    logger.warning(
+                        "Z202 Path Traversal: skipping file escaping workspace root boundary: %s -> %s",
+                        fpath,
+                        resolved_fpath,
+                    )
+                    continue
+            except ValueError:
+                logger.warning(
+                    "Z202 Path Traversal: skipping file escaping workspace root boundary: %s -> %s",
+                    fpath,
+                    resolved_fpath,
+                )
+                continue
+
+            yield fpath
 
 
 def iter_locale_markdown_sources(
@@ -150,8 +174,6 @@ def iter_locale_markdown_sources(
     excluded_dirs = set(config.excluded_dirs)
     for md_file in walk_files(locale_root, excluded_dirs, exclusion_manager, config):
         if md_file.suffix not in DOC_SUFFIXES:
-            continue
-        if md_file.is_symlink():
             continue
         if exclusion_manager.should_exclude_file(md_file, locale_root):
             continue
@@ -198,8 +220,6 @@ def iter_extra_content_markdown_sources(
     for md_file in walk_files(content_root, excluded_dirs, exclusion_manager, config):
         if md_file.suffix not in DOC_SUFFIXES:
             continue
-        if md_file.is_symlink():
-            continue
         if exclusion_manager.should_exclude_file(md_file, content_root):
             continue
         rel = md_file.relative_to(content_root)
@@ -236,8 +256,6 @@ def iter_markdown_sources(
     excluded_dirs = set(config.excluded_dirs)
     for md_file in walk_files(docs_root, excluded_dirs, exclusion_manager, config):
         if md_file.suffix not in DOC_SUFFIXES:
-            continue
-        if md_file.is_symlink():
             continue
         if exclusion_manager.should_exclude_file(md_file, docs_root):
             continue

--- a/src/zenzic/core/validator.py
+++ b/src/zenzic/core/validator.py
@@ -435,9 +435,13 @@ class PolyglotExtractor:
         return extracted
 
     def _mask_comments(self, text: str) -> str:
-        """Mask HTML and MDX comments with spaces of equal length to preserve offsets."""
-        text = _POLY_COMMENT_RE.sub(lambda m: " " * len(m.group(0)), text)
-        text = _POLY_MDX_COMMENT_RE.sub(lambda m: " " * len(m.group(0)), text)
+        """Mask HTML and MDX comments with spaces of equal length, preserving newlines to maintain line offsets."""
+
+        def _repl(m: Any) -> str:
+            return "".join("\n" if c == "\n" else " " for c in m.group(0))
+
+        text = _POLY_COMMENT_RE.sub(_repl, text)
+        text = _POLY_MDX_COMMENT_RE.sub(_repl, text)
         return text
 
     def _mask_inline_code(self, text: str) -> str:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev>
+# SPDX-License-Identifier: Apache-2.0
+"""Security and discovery tests for Symlink Boundary Enforcement (Z202 Path Traversal)."""
+
+import logging
+from pathlib import Path
+import pytest
+
+from zenzic.core.discovery import iter_markdown_sources, walk_files
+from zenzic.core.exclusion import LayeredExclusionManager
+from zenzic.models.config import ZenzicConfig
+
+
+def test_escaping_symlink_skipped_and_logged(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Ensure symlinks resolving outside the repository root are skipped and log Z202 warning."""
+    repo_root = tmp_path / "repo"
+    docs_root = repo_root / "docs"
+    docs_root.mkdir(parents=True)
+
+    # Valid internal markdown file
+    valid_file = docs_root / "guide.md"
+    valid_file.write_text("# Guide\n", encoding="utf-8")
+
+    # Internal symlink pointing inside repo_root
+    internal_target = docs_root / "internal_target.md"
+    internal_target.write_text("# Internal Target\n", encoding="utf-8")
+    internal_symlink = docs_root / "internal_link.md"
+    internal_symlink.symlink_to(internal_target)
+
+    # External file outside repo_root
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    secret_file = outside_dir / "secret.md"
+    secret_file.write_text("# Secret\n", encoding="utf-8")
+
+    # Escaping symlink in docs pointing outside repo_root
+    escaping_symlink = docs_root / "escaping.md"
+    escaping_symlink.symlink_to(secret_file)
+
+    config = ZenzicConfig()
+    exclusion_manager = LayeredExclusionManager(config, docs_root=docs_root, repo_root=repo_root)
+
+    with caplog.at_level(logging.WARNING, logger="zenzic.core.discovery"):
+        discovered = list(iter_markdown_sources(docs_root, config, exclusion_manager))
+
+    discovered_names = {f.name for f in discovered}
+
+    # Internal files and internal symlink must be yielded
+    assert "guide.md" in discovered_names
+    assert "internal_target.md" in discovered_names
+    assert "internal_link.md" in discovered_names
+
+    # Escaping symlink must be skipped
+    assert "escaping.md" not in discovered_names
+
+    # Assert Z202 warning was logged for escaping symlink
+    assert any("Z202 Path Traversal" in record.message for record in caplog.records)

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -655,13 +655,14 @@ class TestScanDocsReferences:
     def test_symlinks_skipped(self, tmp_path: Path) -> None:
         docs = tmp_path / "docs"
         docs.mkdir()
-        (tmp_path / "mkdocs.yml").touch()
-        real = tmp_path / "real.md"
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        real = outside / "real.md"
         real.write_text("[ref]: https://example.com\n", encoding="utf-8")
         (docs / "linked.md").symlink_to(real)
         config = ZenzicConfig()
         docs_root = tmp_path / config.docs_dir
-        mgr = make_mgr(config, repo_root=tmp_path)
+        mgr = make_mgr(config, repo_root=docs)
         reports, _ = scan_docs_references(docs_root, mgr, config=config)
         assert reports == []
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -687,14 +687,16 @@ def test_find_orphans_folder_i18n_nested_file_excluded(tmp_path: Path) -> None:
 def test_find_unused_assets_symlink_skipped(tmp_path: Path) -> None:
     docs = tmp_path / "docs"
     docs.mkdir()
-    real = tmp_path / "real.md"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    real = outside / "real.md"
     real.write_text("![img](assets/img.png)")
     (docs / "linked.md").symlink_to(real)
     assets = docs / "assets"
     assets.mkdir()
     (assets / "img.png").touch()
     config = ZenzicConfig()
-    mgr = make_mgr(config, repo_root=tmp_path)
+    mgr = make_mgr(config, repo_root=docs)
     unused = find_unused_assets(docs, mgr, config=config)
     assert any(p.name == "img.png" for p in unused)
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -361,13 +361,15 @@ class TestInternalLinks:
     def test_symlinks_skipped(self, tmp_path: Path) -> None:
         docs = tmp_path / "docs"
         docs.mkdir()
-        real = tmp_path / "real.md"
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        real = outside / "real.md"
         real.write_text("[broken](ghost.md)")
         (docs / "linked.md").symlink_to(real)
         config = ZenzicConfig()
         docs_root = tmp_path / config.docs_dir
-        mgr = make_mgr(config, repo_root=tmp_path)
-        assert validate_links(docs_root, mgr, repo_root=tmp_path, config=config) == []
+        mgr = make_mgr(config, repo_root=docs)
+        assert validate_links(docs_root, mgr, repo_root=docs, config=config) == []
 
     def test_excluded_dir_not_scanned(self, tmp_path: Path) -> None:
         docs = tmp_path / "docs"
@@ -1251,12 +1253,14 @@ def test_validate_snippets_docs_not_exist(tmp_path: Path) -> None:
 def test_validate_snippets_symlink_skipped(tmp_path: Path) -> None:
     docs = tmp_path / "docs"
     docs.mkdir()
-    real_file = tmp_path / "real.md"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    real_file = outside / "real.md"
     real_file.write_text("```python\ndef broken(\n```")
     (docs / "linked.md").symlink_to(real_file)
     config = ZenzicConfig()
     docs_root = tmp_path / config.docs_dir
-    mgr = make_mgr(config, repo_root=tmp_path)
+    mgr = make_mgr(config, repo_root=docs)
     assert validate_snippets(docs_root, mgr, config=config) == []
 
 
@@ -1781,3 +1785,28 @@ Inline math $\\text{Ref}[\\text{Code}](:32)$ should also be ignored.
     rule_links = _extract_inline_links_with_lines(content)
     rule_urls = [u[0] for u in rule_links]
     assert rule_urls == ["https://example.com/valid"]
+
+
+def test_polyglot_extractor_multiline_comment_line_preservation():
+    """Verify that multiline HTML comments with code blocks inside preserve line numbers for subsequent links."""
+    from zenzic.core.validator import PolyglotExtractor
+
+    content = """# Header (Line 1)
+Line 2 text
+<!--
+Line 4 in comment
+```python
+API_KEY = "sk-live-123"
+```
+Line 8 in comment
+-->
+Line 10 text
+[Real Link](https://example.com/real)
+"""
+    extractor = PolyglotExtractor()
+    extracted = extractor.extract_all_links(content)
+
+    assert len(extracted) == 1
+    link = extracted[0]
+    assert link.url == "https://example.com/real"
+    assert link.line_no == 11


### PR DESCRIPTION
- **Path Sovereignty Guard (`Z202`)**: Enforced strict Path Sovereignty boundary checks in `walk_files` (`src/zenzic/core/discovery.py`) using `path.resolve(strict=False).is_relative_to(resolved_repo_root)`. Symlinks resolving outside the workspace root boundary are safely skipped with a `Z202 Path Traversal` warning. Legitimate internal symlinks inside the workspace root are preserved and scanned normally.
- **AST Line-Offset Determinism**: Updated `_mask_comments` in `PolyglotExtractor` (`src/zenzic/core/validator.py`) to replace non-newline characters in HTML/MDX comments with spaces while retaining `\n` linebreaks. Prevents line collapse in multiline comments and preserves exact line offsets in AST link diagnostics.