### PR TITLE
ci(release): fix brand-kit path in release packaging step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         run: uv build
 
       - name: Package brand kit
-        run: zip -qr brand-kit.zip assets/brand/
+        run: cd docs && zip -qr ../brand-kit.zip assets/brand/
 
       - name: Generate build provenance attestation
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2


### PR DESCRIPTION
## Summary
Fixes brand-kit packaging path in `.github/workflows/release.yml` to package from `docs/assets/brand/` as `assets/brand/` inside `brand-kit.zip`.