### PR TITLE
docs(ui): comprehensive visual refactoring and D.I.A. harmonization

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,10 +1,9 @@
 {
+  "default": true,
   "MD013": false,
-  "MD024": { "siblings_only": true },
+  "MD024": false,
   "MD025": false,
   "MD033": false,
   "MD041": false,
-  "MD046": false,
-  "MD051": false,
-  "MD060": false
+  "MD046": false
 }

--- a/.markdownlint.json.license
+++ b/.markdownlint.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev>
+SPDX-License-Identifier: Apache-2.0

--- a/docs/developers/explanation/sovereign-verification-model.md
+++ b/docs/developers/explanation/sovereign-verification-model.md
@@ -30,6 +30,9 @@ flowchart TD
     C & E & G --> I{"Contains src/zenzic?"}
     I -->|Yes| J["Execute Sovereign Local Core Engine"]
     I -->|No| H
+
+    style H fill:#ef4444,color:#fff
+    style J fill:#10b981,color:#fff
 ```
 
 ---

--- a/docs/developers/how-to/contribute/pull-requests.md
+++ b/docs/developers/how-to/contribute/pull-requests.md
@@ -51,6 +51,8 @@ For a lower-level setup or if you do not have `nox` installed yet, install with 
     pip install pytest pytest-cov ruff mypy pre-commit reuse mkdocs-material mkdocstrings[python] mkdocs-minify-plugin mkdocs-static-i18n
     ```
 
+    Standard pip editable install. Manual installation of all test, lint, docs, and build dependencies.
+
 ### Dependency groups {#dependency-groups}
 
 Zenzic uses [PEP 735](https://peps.python.org/pep-0735/) dependency groups to keep CI fast

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -22,31 +22,59 @@ Operational governance and release troubleshooting start here:
 
 ---
 
-## In this section
+## Core Engineering Guides
 
-- [Writing Plugin Rules](how-to/write-plugin.md) — implement `BaseRule` subclasses, register
+<div class="grid cards" markdown>
 
-  them via `entry_points`, and satisfy the pickle / purity contract.
+- :material-puzzle-edit-outline:{ .lg .middle style="color: #6366f1;" } **[Writing Plugin Rules](how-to/write-plugin.md)**
 
-- [Writing an Adapter](how-to/implement-adapter.md) — implement the `BaseAdapter` protocol
+    ---
 
-  to teach Zenzic about a new documentation engine.
+    Implement `BaseRule` subclasses, satisfy the pickle purity contract, and register entry-points.
 
-- [Example Projects](reference/adapter-examples.md) — four self-contained runnable fixtures that
+    [:material-arrow-right: Read Guide](how-to/write-plugin.md)
 
-  demonstrate correct and incorrect Zenzic configurations.
+- :material-transit-connection-variant:{ .lg .middle style="color: #0284c7;" } **[Writing an Adapter](how-to/implement-adapter.md)**
 
-- [Governance Playbook: Troubleshooting and Invariants](how-to/release-governance-protocol.md) —
+    ---
 
-  Release A CAP policy, suppression rules, and Zenzic failure playbooks.
+    Implement the `BaseAdapter` protocol to teach Zenzic about a new documentation engine topology.
 
-- [Shared Sovereign Verification Model](explanation/sovereign-verification-model.md) —
+    [:material-arrow-right: Read Guide](how-to/implement-adapter.md)
 
-  Family-wide nox/just/CI contract: fail-closed core resolution and local == CI.
+- :material-folder-play-outline:{ .lg .middle style="color: #10b981;" } **[Example Projects](reference/adapter-examples.md)**
 
-- [Supply-Chain Assurance Profile](reference/supply-chain-assurance-profile.md) —
+    ---
 
-  Immediate advanced assurance baseline with auditable controls and runbook commands.
+    Four self-contained runnable fixtures demonstrating correct and incorrect Zenzic configurations.
+
+    [:material-arrow-right: Explore Fixtures](reference/adapter-examples.md)
+
+- :material-shield-lock-open-outline:{ .lg .middle style="color: #f59e0b;" } **[Governance Playbook](how-to/release-governance-protocol.md)**
+
+    ---
+
+    Release CAP policies, suppression rules, and failure troubleshooting playbooks.
+
+    [:material-arrow-right: Read Playbook](how-to/release-governance-protocol.md)
+
+- :material-server-security:{ .lg .middle style="color: #e11d48;" } **[Sovereign Verification Model](explanation/sovereign-verification-model.md)**
+
+    ---
+
+    Fail-closed core resolution, zero-network quality gate, and complete local-to-CI parity.
+
+    [:material-arrow-right: Read Model](explanation/sovereign-verification-model.md)
+
+- :material-certificate-outline:{ .lg .middle style="color: #6366f1;" } **[Supply-Chain Assurance](reference/supply-chain-assurance-profile.md)**
+
+    ---
+
+    Auditable supply-chain controls, security baselines, and verification runbook commands.
+
+    [:material-arrow-right: View Profile](reference/supply-chain-assurance-profile.md)
+
+</div>
 
 ---
 

--- a/docs/developers/reference/ast-foundations.md
+++ b/docs/developers/reference/ast-foundations.md
@@ -60,6 +60,11 @@ flowchart TD
         F -->|Z1xx/Z3xx/Z4xx/Z5xx| G["Quality Score (DQS)"]
         F -->|Z2xx Security Breaches| H["Fatal Security Override (Exit 2/3)"]
     end
+
+    style C fill:#4f46e5,color:#fff
+    style D fill:#0284c7,color:#fff
+    style G fill:#10b981,color:#fff
+    style H fill:#ef4444,color:#fff
 ```
 
 ---

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -62,6 +62,12 @@ flowchart TD
         K -->|Z202 Path Traversal| O["Exit 3 (Boundary Security Violation)"]
         K --> P["SARIF / JSON / GitHub Annotations Output"]
     end
+
+    style L fill:#10b981,color:#fff
+    style M fill:#f59e0b,color:#fff
+    style N fill:#ef4444,color:#fff
+    style O fill:#ef4444,color:#fff
+    style P fill:#0284c7,color:#fff
 ```
 
 !!! note "ADR-075 Invariant: Radical Unawareness"
@@ -551,6 +557,8 @@ flowchart LR
     CMD --> CB["@app.callback()\nconfigure_console()"]
     CB --> EXEC["Command executes\nwith correct console"]
 
+    style BANNER fill:#4f46e5,color:#fff
+    style EXEC fill:#10b981,color:#fff
 ```
 
 The banner always writes to **stdout** (the shared `_shared.console`) so it uses the same color-detection stream as the subsequent command output. The Typer callback runs *after* the banner, which is acceptable — the module-level console already uses `force_terminal=None` (auto-detect) at startup.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -7,6 +7,116 @@ title: Architectural Explanations
 
 # Architectural Explanations
 
-Deep dives into the core architectural principles, determinism guarantees, security boundaries, and mathematical scoring formulas governing Zenzic. These articles explain the design decisions behind the Virtual Site Map (VSM), the three-pass link validation pipeline, Radical Unawareness, and baseline regression tracking.
+Deep dives into the architectural foundation, mathematical models, security boundaries, and determinism guarantees governing Zenzic.
 
-Select an explanation topic from the sidebar navigation menu, or return to the [Main Documentation Overview](../index.md).
+---
+
+## Core Foundations & Topology
+
+<div class="grid cards" markdown>
+
+- :material-sitemap:{ .lg .middle style="color: #6366f1;" } **[Architecture Deep Dive](architecture.md)**
+
+    ---
+
+    The 4-layer architecture: Client Entrypoints, Core Engine, Adapter Layer, and Deterministic Gate.
+
+    [:material-arrow-right: Explore Architecture](architecture.md)
+
+- :material-cpu-64-bit:{ .lg .middle style="color: #6366f1;" } **[Core Execution Mechanics](core-mechanics.md)**
+
+    ---
+
+    Single-pass AST evaluation, dual-stream credential scanning, and graph cycle resolution.
+
+    [:material-arrow-right: Read Mechanics](core-mechanics.md)
+
+- :material-magnify-scan:{ .lg .middle style="color: #6366f1;" } **[Discovery Engine](discovery.md)**
+
+    ---
+
+    Hierarchical exclusion resolution, immutable system guardrails, and .gitignore traversal.
+
+    [:material-arrow-right: Read Discovery](discovery.md)
+
+- :material-vector-polyline:{ .lg .middle style="color: #6366f1;" } **[Structural Integrity](structural-integrity.md)**
+
+    ---
+
+    Lossless AST compilation, Virtual Site Map (VSM) indexing, and polyglot link extraction.
+
+    [:material-arrow-right: Read Foundations](structural-integrity.md)
+
+</div>
+
+---
+
+## Mathematical Scoring & Governance
+
+<div class="grid cards" markdown>
+
+- :material-calculator:{ .lg .middle style="color: #10b981;" } **[Document Quality Score (DQS)](scoring-system.md)**
+
+    ---
+
+    The weighted mathematical formula, category ceilings, and non-linear penalties.
+
+    [:material-arrow-right: Explore Scoring](scoring-system.md)
+
+- :material-scale-balance:{ .lg .middle style="color: #10b981;" } **[Managed Technical Debt](exclusion-design.md)**
+
+    ---
+
+    Why unmonitored ignores degrade quality and how Zenzic bounds debt via the Suppression CAP.
+
+    [:material-arrow-right: Read Governance](exclusion-design.md)
+
+- :material-history:{ .lg .middle style="color: #10b981;" } **[Baseline Regression Tracking](baseline-tracking.md)**
+
+    ---
+
+    Snapshotting legacy documentation debt and enforcing zero new defects in pull requests.
+
+    [:material-arrow-right: Read Baseline](baseline-tracking.md)
+
+- :material-shield-lock:{ .lg .middle style="color: #10b981;" } **[Zero-Network Privacy Gate](privacy-gate.md)**
+
+    ---
+
+    Total isolation: why Zenzic never transmits source files, metadata, or telemetry over the wire.
+
+    [:material-arrow-right: Read Privacy Gate](privacy-gate.md)
+
+</div>
+
+---
+
+## Developer Experience & Tooling
+
+<div class="grid cards" markdown>
+
+- :material-magic-staff:{ .lg .middle style="color: #0284c7;" } **[Auto-Fix Philosophy](auto-fix-philosophy.md)**
+
+    ---
+
+    Atomic AST mutations, idempotency guarantees, and safe automated code block formatting.
+
+    [:material-arrow-right: Read Auto-Fix](auto-fix-philosophy.md)
+
+- :material-code-json:{ .lg .middle style="color: #0284c7;" } **[Language Server Architecture](language-server-architecture.md)**
+
+    ---
+
+    Real-time incremental AST parsing, LSP protocol handler, and debounce queue design.
+
+    [:material-arrow-right: Read LSP Design](language-server-architecture.md)
+
+- :material-github:{ .lg .middle style="color: #0284c7;" } **[GitHub Action Internals](github-action-internals.md)**
+
+    ---
+
+    Pure runner execution, zero API token dependency, and native SARIF generation.
+
+    [:material-arrow-right: Read Action Internals](github-action-internals.md)
+
+</div>

--- a/docs/how-to/configure-ci-cd.md
+++ b/docs/how-to/configure-ci-cd.md
@@ -40,6 +40,14 @@ flowchart TD
         F & G & H & I --> J["SARIF Output (zenzic-results.sarif)"]
         J --> K["GitHub Code Scanning / Inline Annotations"]
     end
+
+    style F fill:#10b981,color:#fff
+    style G fill:#f59e0b,color:#fff
+    style H fill:#ef4444,color:#fff
+    style I fill:#ef4444,color:#fff
+    style C fill:#4f46e5,color:#fff
+    style J fill:#0284c7,color:#fff
+    style K fill:#0284c7,color:#fff
 ```
 
 ---

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -7,6 +7,148 @@ title: How-To Guides
 
 # How-To Guides
 
-This section provides practical, step-by-step instructions for integrating, configuring, and extending Zenzic across your documentation workflow. Whether you are setting up local pre-commit hooks, configuring CI/CD quality gates, or building custom rule plugins, these guides offer clear, task-oriented solutions.
+Task-oriented, step-by-step instructions for installing, configuring, automating, and extending Zenzic across your documentation projects.
 
-Explore the step-by-step guides listed in the navigation menu, or return to the [Main Documentation Overview](../index.md).
+---
+
+## Getting Started & Core Setup
+
+<div class="grid cards" markdown>
+
+- :material-rocket-launch:{ .lg .middle style="color: #6366f1;" } **[Installation & Environment](install.md)**
+
+    ---
+
+    Install Zenzic globally via `uv tool`, ephemerally via `uvx`, or locally with `pip`.
+
+    [:material-arrow-right: Read Guide](install.md)
+
+- :material-tune:{ .lg .middle style="color: #6366f1;" } **[Configuration Strategy](initialize-configuration.md)**
+
+    ---
+
+    Scaffold and fine-tune your project's `.zenzic.toml` policy file with `zenzic init`.
+
+    [:material-arrow-right: Read Guide](initialize-configuration.md)
+
+- :material-microsoft-visual-studio-code:{ .lg .middle style="color: #6366f1;" } **[Editor & VS Code Setup](editor-integrations.md)**
+
+    ---
+
+    Configure real-time in-editor diagnostics, LSP auto-provisioning, and code actions.
+
+    [:material-arrow-right: Read Guide](editor-integrations.md)
+
+</div>
+
+---
+
+## Pipelines & Automation
+
+<div class="grid cards" markdown>
+
+- :material-pipe:{ .lg .middle style="color: #0284c7;" } **[CI/CD Quality Gates](configure-ci-cd.md)**
+
+    ---
+
+    Enforce zero-regression gates in GitHub Actions, GitLab CI, and custom CI pipelines.
+
+    [:material-arrow-right: Read Guide](configure-ci-cd.md)
+
+- :material-git:{ .lg .middle style="color: #0284c7;" } **[Pre-Commit & Git Hooks](workflow-integration.md)**
+
+    ---
+
+    Integrate sub-50ms secret scanning and fast link linting on staged files.
+
+    [:material-arrow-right: Read Guide](workflow-integration.md)
+
+- :material-shield-badge-outline:{ .lg .middle style="color: #0284c7;" } **[DQS Status Badges](add-badges.md)**
+
+    ---
+
+    Generate and stamp live Document Quality Score shields directly into your `README.md`.
+
+    [:material-arrow-right: Read Guide](add-badges.md)
+
+</div>
+
+---
+
+## Governance & Quality Management
+
+<div class="grid cards" markdown>
+
+- :material-scale-balance:{ .lg .middle style="color: #10b981;" } **[Managing Technical Debt](handle-technical-debt.md)**
+
+    ---
+
+    Audit suppressions, enforce directory policies, and manage the strict `suppression_cap`.
+
+    [:material-arrow-right: Read Guide](handle-technical-debt.md)
+
+- :material-shield-key-outline:{ .lg .middle style="color: #10b981;" } **[Zero-Network Privacy Gate](configure-privacy-gate.md)**
+
+    ---
+
+    Protect private repositories with offline verification and polyglot secret scanning.
+
+    [:material-arrow-right: Read Guide](configure-privacy-gate.md)
+
+- :material-link-variant:{ .lg .middle style="color: #10b981;" } **[Cross-Site & Remote Links](manage-cross-site-links.md)**
+
+    ---
+
+    Manage external HTTP link timeouts, domain exclusion lists, and offline builds.
+
+    [:material-arrow-right: Read Guide](manage-cross-site-links.md)
+
+- :material-palette-outline:{ .lg .middle style="color: #10b981;" } **[Brand Governance System](use-brand-system.md)**
+
+    ---
+
+    Configure brand term dictionaries and eradicate obsolete product naming conventions.
+
+    [:material-arrow-right: Read Guide](use-brand-system.md)
+
+- :material-share-variant-outline:{ .lg .middle style="color: #10b981;" } **[Social Metadata & SEO](configure-social-metadata.md)**
+
+    ---
+
+    Validate OpenGraph social cards, meta descriptions, and sitemap topology.
+
+    [:material-arrow-right: Read Guide](configure-social-metadata.md)
+
+</div>
+
+---
+
+## Extensibility & Migration
+
+<div class="grid cards" markdown>
+
+- :material-puzzle-outline:{ .lg .middle style="color: #f59e0b;" } **[Custom Rule Plugins](add-custom-rules.md)**
+
+    ---
+
+    Author deterministic custom rules using the Python Custom Rule SDK v3.
+
+    [:material-arrow-right: Read Guide](add-custom-rules.md)
+
+- :material-swap-horizontal:{ .lg .middle style="color: #f59e0b;" } **[Engine Migration Guide](migrate-engines.md)**
+
+    ---
+
+    Migrate documentation seamlessly between MkDocs, Zensical, and Docusaurus.
+
+    [:material-arrow-right: Read Guide](migrate-engines.md)
+
+- :material-lifebuoy:{ .lg .middle style="color: #f59e0b;" } **[Diagnostic Troubleshooting](troubleshooting.md)**
+
+    ---
+
+    Comprehensive runbook for diagnosing CI timeouts, cache invalidation, and rule alerts.
+
+    [:material-arrow-right: Read Guide](troubleshooting.md)
+
+</div>

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -19,7 +19,7 @@ Ensure Python 3.10 or higher is installed on your system. Select your preferred 
 
 === "uv (Recommended)"
 
-    !!! tip "Zero Environment Contamination"
+    !!! tip "Zero Environment Contamination (Recommended)"
         We strongly recommend using `uv` or `uvx` to execute Zenzic in isolated environments without dependency conflicts.
 
     **Global Binary Install:**
@@ -41,6 +41,9 @@ Ensure Python 3.10 or higher is installed on your system. Select your preferred 
 
 === "pip"
 
+    !!! info "Standard Environment Installation"
+        Installs Zenzic via `pip` into an active virtual environment or global user site.
+
     **Virtual Environment Install:**
     ```bash title="Terminal"
     python -m venv .venv
@@ -57,14 +60,17 @@ Ensure Python 3.10 or higher is installed on your system. Select your preferred 
 
 === "Git Source Execution"
 
-    Execute directly from GitHub without local installation:
+    !!! example "Ephemeral & Version-Pinned Execution"
+        Execute Zenzic directly from the GitHub repository using `uvx` without maintaining a local git clone or manual package updates.
+
+    **Execute latest main branch:**
     ```bash title="Terminal"
     uvx --from git+https://github.com/PythonWoods/zenzic zenzic .
     ```
 
-    Pin to a specific version tag for deterministic execution:
+    **Pin to a specific version tag for deterministic execution:**
     ```bash title="Terminal"
-    uvx --from git+https://github.com/PythonWoods/zenzic@v0.25.0 zenzic .
+    uvx --from git+https://github.com/PythonWoods/zenzic@v0.30.0 zenzic .
     ```
 
 ### Static analysis only — no build runtime required {#lean-agnostic}

--- a/docs/reference/finding-codes.md
+++ b/docs/reference/finding-codes.md
@@ -34,15 +34,15 @@ The code registry is governed by immutable contract surfaces:
 ## Category Overview
 
 | **Category** | **Range** | **Purpose** | **Default Severity** | **Suppressible?** |
-|---|---|---|---|---|
-| **Z0xx** | Migration & Compatibility | Engine deprecation; migration guidance | `error` | ❌ No (fatal abort) |
-| **Z1xx** | Link Integrity | Broken, empty, circular links; orphaned pages; path issues | `error`/`warning`/`info` | ✅ Yes |
-| **Z2xx** | Security (credential scanner) | Secret detection; path traversal; security incidents | `warning`/`security_breach`/`security_incident` | 🔒 **Never** |
-| **Z3xx** | Reference Integrity | Dangling/duplicate reference definitions | `error`/`warning` | ✅ Yes |
-| **Z4xx** | Structure | Directory indexes, orphan pages, missing alt text, config assets | `info`/`warning` | ✅ Yes |
-| **Z5xx** | Content Quality | Placeholder text, short content, snippet validation, regressions | `warning`/`error` | ✅ Yes |
-| **Z6xx** | Governance | Brand obsolescence, required frontmatter, forbidden domain references (opt-in) | `warning` | ✅ Yes |
-| **Z9xx** | Engine & System | Rule execution errors, timeouts, system-level diagnostics | `error`/`warning` | ✅ Yes |
+|---|---|---|---|:---:|
+| **Z0xx** | Migration & Compatibility | Engine deprecation; migration guidance | :material-alert-circle:{ style="color: #e11d48;" } `error` | ❌ No (fatal abort) |
+| **Z1xx** | Link Integrity | Broken, empty, circular links; orphaned pages; path issues | :material-alert-circle:{ style="color: #e11d48;" } `error` / :material-alert:{ style="color: #f59e0b;" } `warning` | ✅ Yes |
+| **Z2xx** | Security Surface | Secret detection; path traversal; security breaches | :material-shield-alert:{ style="color: #ef4444;" } `fatal` (Exit 2/3) | 🔒 **Never** |
+| **Z3xx** | Reference Integrity | Dangling/duplicate reference definitions | :material-alert-circle:{ style="color: #e11d48;" } `error` / :material-alert:{ style="color: #f59e0b;" } `warning` | ✅ Yes |
+| **Z4xx** | Topology & Structure | Directory indexes, orphan pages, config assets | :material-information:{ style="color: #0284c7;" } `info` / :material-alert:{ style="color: #f59e0b;" } `warning` | ✅ Yes |
+| **Z5xx** | Content Quality | Placeholders, short content, snippet validation | :material-alert:{ style="color: #f59e0b;" } `warning` / :material-alert-circle:{ style="color: #e11d48;" } `error` | ✅ Yes |
+| **Z6xx** | Governance | Brand obsolescence, dead suppressions, domain policies | :material-alert:{ style="color: #f59e0b;" } `warning` | ✅ Yes |
+| **Z9xx** | Engine & System | Rule execution errors, timeouts, system faults | :material-alert-circle:{ style="color: #e11d48;" } `error` | ✅ Yes |
 
 !!! info "Per-line suppression syntax"
     **Markdown (.md):** `<!-- zenzic:ignore: Zxxx -->`\
@@ -51,12 +51,12 @@ The code registry is governed by immutable contract surfaces:
 
 ### Exit Code Contract
 
-| Exit Code | Meaning | Suppressible? |
-| :---: | :--- | :--- |
-| **0** | All checks passed (or suppressed via `--exit-zero`) | — |
-| **1** | Errors and warnings detected; use `--strict` to promote warnings | ✅ Yes |
-| **2** | Security breaches (Z201, Z204). **Never** suppressed | ❌ Never |
-| **3** | Security incidents (Z203 PATH_TRAVERSAL_FATAL). **Never** suppressed, even with `--exit-zero` | ❌ Never |
+| Exit Code | Meaning | Suppressible? | Execution Impact |
+| :---: | :--- | :---: | :--- |
+| **0** | All checks passed (or suppressed via `--exit-zero`) | — | Clean Pass / Normal Completion |
+| **1** | Errors and warnings detected; use `--strict` to promote warnings | ✅ Yes | Standard Gate Failure |
+| **2** | Security breaches (Z201, Z204). **Never** suppressed | ❌ Never | **Fatal Security Override** |
+| **3** | Security incidents (Z203 PATH_TRAVERSAL_FATAL). **Never** suppressed | ❌ Never | **Fatal Boundary Breach** |
 
 ---
 

--- a/docs/reference/suppression-policy.md
+++ b/docs/reference/suppression-policy.md
@@ -54,6 +54,12 @@ flowchart TD
     F -->|No| H{"Inline Comment Present? (Level 1)"}
     H -->|Yes| I["INLINE_IGNORE (+1 Debt Pt)"]
     H -->|No| J["EMIT FINDING (Exit 1)"]
+
+    style C fill:#ef4444,color:#fff
+    style E fill:#10b981,color:#fff
+    style G fill:#f59e0b,color:#fff
+    style I fill:#f59e0b,color:#fff
+    style J fill:#e11d48,color:#fff
 ```
 
 ---
@@ -62,17 +68,41 @@ flowchart TD
 
 Zenzic provides four distinct suppression levels designed for specific architectural contexts:
 
-`Level 1: Inline Comment`
-: `<!-- zenzic:ignore: ZXXX -->` comment placed at the end of a line. Silences a specific finding on a single line. Costs **1 Debt Point**.
+<div class="grid cards" markdown>
 
-`Level 2: Per-File Ignore`
-: `[governance.per_file_ignores]` configuration in `.zenzic.toml`. Silences a specific rule across a file glob. Costs **1 Debt Point per entry**.
+- :material-code-tags:{ .lg .middle } **Level 1: Inline Comment**
 
-`Level 3: Exclusion Zone`
-: `excluded_dirs` or `excluded_file_patterns` in `.zenzic.toml`. Completely removes non-documentation directories (`build/`, `dist/`) from evaluation. Costs **0 Debt Points** (Not audited).
+    ---
 
-`Level 4: Directory Policy`
-: `[governance.directory_policies]` configuration in `.zenzic.toml`. Strategic organizational exemptions for historical assets (e.g. legacy blog posts). Emits `[POLICY_EXEMPTION]` in audit mode. Costs **0 Debt Points**.
+    `<!-- zenzic:ignore: ZXXX -->` placed at the end of a line. Silences a finding on a single line.
+
+    **Cost**: `1 Debt Point`
+
+- :material-file-document-outline:{ .lg .middle } **Level 2: Per-File Ignore**
+
+    ---
+
+    `[governance.per_file_ignores]` in `.zenzic.toml`. Silences a specific rule across a file glob.
+
+    **Cost**: `1 Debt Point per entry`
+
+- :material-folder-remove-outline:{ .lg .middle } **Level 3: Exclusion Zone**
+
+    ---
+
+    `excluded_dirs` or `excluded_file_patterns` in `.zenzic.toml`. Removes directories from evaluation.
+
+    **Cost**: `0 Debt Points` (Not audited)
+
+- :material-shield-home-outline:{ .lg .middle } **Level 4: Directory Policy**
+
+    ---
+
+    `[governance.directory_policies]` in `.zenzic.toml`. Strategic organizational exemptions for legacy doc trees.
+
+    **Cost**: `0 Debt Points` (`[POLICY_EXEMPTION]`)
+
+</div>
 
 ---
 

--- a/docs/rules/Z000.md
+++ b/docs/rules/Z000.md
@@ -5,11 +5,23 @@ title: "Z000: UNSUPPORTED_ENGINE"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 0.0 (Fatal)
-**Category**: `config`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z000: UNSUPPORTED_ENGINE
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -21,23 +33,9 @@ Operating with an unsupported engine identifier breaks Virtual Site Map (VSM) ro
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z000)
-
-```toml
-# .zenzic.toml - BAD: Unknown or deprecated engine specifier
-engine = "hugo_v1_legacy"
-```
-
-### Good (Resolves Z000)
-
-```toml
-# .zenzic.toml - GOOD: Use a supported engine target
-engine = "mkdocs"
-```
-
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # .zenzic.toml
 # Supported values include "mkdocs", "docusaurus", or omit to auto-discover
 engine = "mkdocs"

--- a/docs/rules/Z001.md
+++ b/docs/rules/Z001.md
@@ -5,11 +5,23 @@ title: "Z001: CORE_CONFIG_STRUCTURE"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 0.0 (Fatal)
-**Category**: `config`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z001: CORE_CONFIG_STRUCTURE
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -21,27 +33,9 @@ An invalid configuration halts execution immediately (`Exit 1`) before any files
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z001)
-
-```text
-# .zenzic.toml - BAD: String supplied to boolean setting & unclosed header
-strict = "yes"
-[governance.directory_policies
-```
-
-### Good (Resolves Z001)
-
-```toml
-# .zenzic.toml - GOOD: Valid TOML data types and headers
-strict = true
-
-[governance.directory_policies]
-"docs/blog/**" = ["Z410"]
-```
-
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Validate configuration with standard TOML syntax rules
 strict = true
 fail_under = 90

--- a/docs/rules/Z101.md
+++ b/docs/rules/Z101.md
@@ -5,11 +5,23 @@ title: "Z101: LINK_BROKEN"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 8.0 points
-**Category**: `structural`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z101: LINK_BROKEN
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -21,23 +33,31 @@ Linking to non-existent target files or unrendered routes produces broken HTTP 4
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z101)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Linking to a non-existent file or route -->
-Please refer to our [Installation Guide](../setup/installation.md) for details.
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z101)**
 
-### Good (Resolves Z101)
+    ---
 
-```markdown
-<!-- GOOD: Linking to an existing, served page in the VSM -->
-Please refer to our [Installation Guide](../how-to/install.md) for details.
-```
+    ```markdown title="docs/example.md"
+    <!-- BAD: Linking to a non-existent file or route -->
+    Please refer to our [Installation Guide](../setup/installation.md) for details.
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z101)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Linking to an existing, served page in the VSM -->
+    Please refer to our [Installation Guide](../how-to/install.md) for details.
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # .zenzic.toml - Exclude specific external domain URLs from broken link checks
 excluded_external_urls = [
     "https://github.com/PythonWoods/zenzic",

--- a/docs/rules/Z102.md
+++ b/docs/rules/Z102.md
@@ -5,11 +5,23 @@ title: "Z102: ANCHOR_MISSING"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 5.0 points
-**Category**: `structural`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z102: ANCHOR_MISSING
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -21,25 +33,33 @@ Fragment links pointing to missing anchors navigate to the page top but fail to 
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z102)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Anchor fragment #security-gate does not exist on target page -->
-See the [Security Gate Options](../how-to/configure-privacy-gate.md#security-gate).
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z102)**
 
-### Good (Resolves Z102)
+    ---
 
-```markdown
-<!-- GOOD: Target page contains explicit anchor attribute -->
-## Security Options {#security-gate}
+    ```markdown title="docs/example.md"
+    <!-- BAD: Anchor fragment #security-gate does not exist on target page -->
+    See the [Security Gate Options](../how-to/configure-privacy-gate.md#security-gate).
+    ```
 
-Configure privacy gate settings below...
-```
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z102)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Target page contains explicit anchor attribute -->
+    ## Security Options {#security-gate}
+
+    Configure privacy gate settings below...
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # .zenzic.toml
 validate_same_page_anchors = true
 ```

--- a/docs/rules/Z103.md
+++ b/docs/rules/Z103.md
@@ -5,11 +5,23 @@ title: "Z103: ORPHAN_LINK"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 2.0 points
-**Category**: `structural`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z103: ORPHAN_LINK
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -21,19 +33,27 @@ While the target file is physically present, the static site generator will not 
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z103)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Linking to an unlisted draft file -->
-Check the [Draft Architecture](../../drafts/arch-v2.md).
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z103)**
 
-### Good (Resolves Z103)
+    ---
 
-```markdown
-<!-- GOOD: Link to a file registered in site navigation -->
-Check the [Architecture Explanation](../explanation/architecture.md).
-```
+    ```markdown title="docs/example.md"
+    <!-- BAD: Linking to an unlisted draft file -->
+    Check the [Draft Architecture](../../drafts/arch-v2.md).
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z103)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Link to a file registered in site navigation -->
+    Check the [Architecture Explanation](../explanation/architecture.md).
+    ```
+
+</div>
 
 ## Configuration
 

--- a/docs/rules/Z104.md
+++ b/docs/rules/Z104.md
@@ -5,11 +5,23 @@ title: "Z104: FILE_NOT_FOUND"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 8.0 points
-**Category**: `structural`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z104: FILE_NOT_FOUND
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,23 +31,31 @@ This rule is emitted when a document references a local binary or image asset (s
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z104)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Image asset file missing on disk -->
-![System Topology](../assets/diagrams/topology-v2.png)
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z104)**
 
-### Good (Resolves Z104)
+    ---
 
-```markdown
-<!-- GOOD: Referenced image asset exists on disk -->
-![System Topology](../assets/diagrams/topology.png)
-```
+    ```markdown title="docs/example.md"
+    <!-- BAD: Image asset file missing on disk -->
+    ![System Topology](../assets/diagrams/topology-v2.png)
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z104)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Referenced image asset exists on disk -->
+    ![System Topology](../assets/diagrams/topology.png)
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # .zenzic.toml - Set relative docs root directory
 docs_dir = "docs"
 ```

--- a/docs/rules/Z105.md
+++ b/docs/rules/Z105.md
@@ -5,11 +5,23 @@ title: "Z105: ABSOLUTE_PATH"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 2.0 points
-**Category**: `structural`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z105: ABSOLUTE_PATH
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -21,23 +33,31 @@ Absolute paths break portability across different operating systems, CI build ru
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z105)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Absolute root-relative path specifier -->
-Read the [Setup Guide](/docs/how-to/setup.md).
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z105)**
 
-### Good (Resolves Z105)
+    ---
 
-```markdown
-<!-- GOOD: Portable relative path calculated from source file -->
-Read the [Setup Guide](../how-to/setup.md).
-```
+    ```markdown title="docs/example.md"
+    <!-- BAD: Absolute root-relative path specifier -->
+    Read the [Setup Guide](/docs/how-to/setup.md).
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z105)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Portable relative path calculated from source file -->
+    Read the [Setup Guide](../how-to/setup.md).
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Enforced across workspace when strict mode is active
 strict = true
 ```

--- a/docs/rules/Z106.md
+++ b/docs/rules/Z106.md
@@ -5,11 +5,23 @@ title: "Z106: CIRCULAR_LINK"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `note`
-**Penalty**: 0.0 points
-**Category**: `structural`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z106: CIRCULAR_LINK
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -21,26 +33,34 @@ While not fatal to static site rendering, cyclic navigation loops can confuse re
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z106)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- page-a.md links to page-b.md -->
-See [Section B](page-b.md).
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z106)**
 
-<!-- page-b.md links back to page-a.md -->
-Return to [Section A](page-a.md).
-```
+    ---
 
-### Good (Resolves Z106)
+    ```markdown title="docs/example.md"
+    <!-- page-a.md links to page-b.md -->
+    See [Section B](page-b.md).
 
-```markdown
-<!-- Restructure navigation to form a linear/hierarchical reading path -->
-See [Section B](page-b.md).
-```
+    <!-- page-b.md links back to page-a.md -->
+    Return to [Section A](page-a.md).
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z106)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- Restructure navigation to form a linear/hierarchical reading path -->
+    See [Section B](page-b.md).
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Informational diagnostic; no point deduction subtracted from DQS
 ```
 

--- a/docs/rules/Z107.md
+++ b/docs/rules/Z107.md
@@ -5,11 +5,23 @@ title: "Z107: CIRCULAR_ANCHOR"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 1.0 point
-**Category**: `structural`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z107: CIRCULAR_ANCHOR
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,23 +31,31 @@ This rule is emitted when an anchor link's visible text label slugifies to the e
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z107)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Link text label matches fragment slug -->
-[#installation](#installation)
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z107)**
 
-### Good (Resolves Z107)
+    ---
 
-```markdown
-<!-- GOOD: Descriptive text label explaining the jump destination -->
-[Jump to Installation Guide](#installation)
-```
+    ```markdown title="docs/example.md"
+    <!-- BAD: Link text label matches fragment slug -->
+    [#installation](#installation)
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z107)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Descriptive text label explaining the jump destination -->
+    [Jump to Installation Guide](#installation)
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Can be ignored for didactic tutorial pages via directory_policies
 [governance.directory_policies]
 "docs/tutorials/examples/z1xx-links/**" = ["Z107"]

--- a/docs/rules/Z108.md
+++ b/docs/rules/Z108.md
@@ -5,11 +5,23 @@ title: "Z108: EMPTY_LINK_TEXT"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 1.0 point
-**Category**: `structural`
-**Auto-fixable**: Yes
-**Opt-in**: No
+# Z108: EMPTY_LINK_TEXT
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -21,19 +33,27 @@ Links without accessible text labels violate web accessibility standards (WCAG 2
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z108)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Empty or whitespace-only link label -->
-[](https://zenzic.dev/docs)
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z108)**
 
-### Good (Resolves Z108)
+    ---
 
-```markdown
-<!-- GOOD: Accessible descriptive link text -->
-[Zenzic Documentation Catalog](https://zenzic.dev/docs)
-```
+    ```markdown title="docs/example.md"
+    <!-- BAD: Empty or whitespace-only link label -->
+    [](https://zenzic.dev/docs)
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z108)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Accessible descriptive link text -->
+    [Zenzic Documentation Catalog](https://zenzic.dev/docs)
+    ```
+
+</div>
 
 ## Configuration
 

--- a/docs/rules/Z109.md
+++ b/docs/rules/Z109.md
@@ -5,11 +5,23 @@ title: "Z109: EXTERNAL_LINK_BROKEN"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 3.0 points
-**Category**: `structural`
-**Auto-fixable**: No
-**Opt-in**: Yes — only active under `--strict` (see Activation below)
+# Z109: EXTERNAL_LINK_BROKEN
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -43,19 +55,27 @@ This is the recommended pattern for air-gapped CI environments or developer mach
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z109)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Link to a non-existent or 404 remote web page -->
-Refer to [External Specifications](https://example.invalid/broken-spec).
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z109)**
 
-### Good (Resolves Z109)
+    ---
 
-```markdown
-<!-- GOOD: Link to a verified live external web page -->
-Refer to [External Specifications](https://example.com/valid-spec).
-```
+    ```markdown title="docs/example.md"
+    <!-- BAD: Link to a non-existent or 404 remote web page -->
+    Refer to [External Specifications](https://example.invalid/broken-spec).
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z109)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Link to a verified live external web page -->
+    Refer to [External Specifications](https://example.com/valid-spec).
+    ```
+
+</div>
 
 ## Configuration
 

--- a/docs/rules/Z110.md
+++ b/docs/rules/Z110.md
@@ -5,12 +5,23 @@ title: "Z110: CONFIG_SYNTAX_ERROR"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: Fatal Configuration Error (Analysis Bypassed)
-**Category**: `configuration`
-**Auto-fixable**: No
-**Opt-in**: No
-**Suppression**: Non-suppressible
+# Z110: CONFIG_SYNTAX_ERROR
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z111.md
+++ b/docs/rules/Z111.md
@@ -5,12 +5,23 @@ title: "Z111: CONFIG_SCHEMA_ERROR"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: Fatal Configuration Error (Analysis Bypassed)
-**Category**: `configuration`
-**Auto-fixable**: No
-**Opt-in**: No
-**Suppression**: Non-suppressible
+# Z111: CONFIG_SCHEMA_ERROR
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z113.md
+++ b/docs/rules/Z113.md
@@ -5,11 +5,23 @@ title: "Z113: AUTHOR_KEY_COLLISION"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 2.0 points
-**Category**: `structural`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z113: AUTHOR_KEY_COLLISION
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 

--- a/docs/rules/Z114.md
+++ b/docs/rules/Z114.md
@@ -5,11 +5,23 @@ title: "Z114: LARGE_PAGINATION_SET"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `note`
-**Penalty**: 0.0 points
-**Category**: `content`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z114: LARGE_PAGINATION_SET
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -21,21 +33,9 @@ Massive pagination sets increase site build times and RAM usage during static si
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z114)
-
-```text
-docs/blog/posts/ -> Generates 250 un-categorized pagination index pages.
-```
-
-### Good (Resolves Z114)
-
-```text
-docs/blog/posts/ -> Reorganize blog posts into categorized year/tag subfolders.
-```
-
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Informational diagnostic; no point deduction
 ```
 

--- a/docs/rules/Z120.md
+++ b/docs/rules/Z120.md
@@ -5,11 +5,23 @@ title: "Z120: UNKNOWN_HTML_ATTRIBUTE"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 points
-**Category**: `html_hygiene`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z120: UNKNOWN_HTML_ATTRIBUTE
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,17 +31,25 @@ Emitted by the Polyglot Extractor when an HTML tag (`<a>` or `<img>`) in Markdow
 
 Remove unapproved custom HTML attributes or use `data-zenzic-ignore` to suppress intentional custom attributes.
 
-### Bad (Triggers Z120)
+<div class="grid cards" markdown>
 
-```html
-<a href="/docs" custom-unknown-attr="value">Docs</a>
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z120)**
 
-### Good (Resolves Z120)
+    ---
 
-```html
-<a href="/docs" target="_blank" rel="noopener">Docs</a>
-```
+    ```html title="docs/example.md"
+    <a href="/docs" custom-unknown-attr="value">Docs</a>
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z120)**
+
+    ---
+
+    ```html title="docs/example.md"
+    <a href="/docs" target="_blank" rel="noopener">Docs</a>
+    ```
+
+</div>
 
 ## Reference
 

--- a/docs/rules/Z121.md
+++ b/docs/rules/Z121.md
@@ -5,11 +5,23 @@ title: "Z121: MISSING_OR_EMPTY_HREF"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 1.0 points
-**Category**: `structural`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z121: MISSING_OR_EMPTY_HREF
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,18 +31,26 @@ Emitted when an HTML `<a>` tag lacks an `href` attribute or has an empty `href="
 
 Provide a valid relative or absolute target URL in the `href` attribute.
 
-### Bad (Triggers Z121)
+<div class="grid cards" markdown>
 
-```html
-<a href="">Empty Link</a>
-<a>Missing Href</a>
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z121)**
 
-### Good (Resolves Z121)
+    ---
 
-```html
-<a href="/guide">Valid Link</a>
-```
+    ```html title="docs/example.md"
+    <a href="">Empty Link</a>
+    <a>Missing Href</a>
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z121)**
+
+    ---
+
+    ```html title="docs/example.md"
+    <a href="/guide">Valid Link</a>
+    ```
+
+</div>
 
 ## Reference
 

--- a/docs/rules/Z122.md
+++ b/docs/rules/Z122.md
@@ -5,11 +5,23 @@ title: "Z122: JUMP_LINK_DETECTED"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 points
-**Category**: `html_hygiene`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z122: JUMP_LINK_DETECTED
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,17 +31,25 @@ Emitted when an HTML `<a>` tag uses `href="#"`, indicating a placeholder or unro
 
 Replace `href="#"` with a specific fragment destination or target page URL.
 
-### Bad (Triggers Z122)
+<div class="grid cards" markdown>
 
-```html
-<a href="#">Top</a>
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z122)**
 
-### Good (Resolves Z122)
+    ---
 
-```html
-<a href="#section-heading">Section Heading</a>
-```
+    ```html title="docs/example.md"
+    <a href="#">Top</a>
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z122)**
+
+    ---
+
+    ```html title="docs/example.md"
+    <a href="#section-heading">Section Heading</a>
+    ```
+
+</div>
 
 ## Reference
 

--- a/docs/rules/Z123.md
+++ b/docs/rules/Z123.md
@@ -5,11 +5,23 @@ title: "Z123: NON_HTTP_SCHEME"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `note`
-**Penalty**: 0.0 points
-**Category**: None
-**Auto-fixable**: No
-**Opt-in**: No
+# Z123: NON_HTTP_SCHEME
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 

--- a/docs/rules/Z124.md
+++ b/docs/rules/Z124.md
@@ -5,11 +5,23 @@ title: "Z124: OPAQUE_HTML_CONTEXT"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 1.0 points
-**Category**: `structural`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z124: OPAQUE_HTML_CONTEXT
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 

--- a/docs/rules/Z201.md
+++ b/docs/rules/Z201.md
@@ -5,11 +5,23 @@ title: "Z201: CREDENTIAL_SECRET"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 0.0 (Fatal Exit 2)
-**Category**: `security`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z201: CREDENTIAL_SECRET
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -21,23 +33,9 @@ Hardcoding secrets in documentation source files exposes infrastructure credenti
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z201)
-
-```python
-# BAD: Real credential hardcoded in documentation snippet
-aws_secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-```
-
-### Good (Resolves Z201)
-
-```python
-# GOOD: Use environment variables or sanitized placeholders
-aws_secret = os.environ["AWS_SECRET_ACCESS_KEY"]
-```
-
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Non-suppressible security code. Triggers Security Override (DQS -> 0/100).
 ```
 

--- a/docs/rules/Z202.md
+++ b/docs/rules/Z202.md
@@ -5,11 +5,23 @@ title: "Z202: PATH_TRAVERSAL"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 0.0 (Fatal Exit 2)
-**Category**: `security`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z202: PATH_TRAVERSAL
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,23 +31,31 @@ This security rule is triggered when a relative link or asset reference uses par
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z202)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Traversal escaping the docs/ directory root -->
-Download [Internal Secret](../../../secrets/keys.json).
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z202)**
 
-### Good (Resolves Z202)
+    ---
 
-```markdown
-<!-- GOOD: Target file resides inside designated docs/ workspace -->
-Download [Public Keys](../assets/public-keys.json).
-```
+    ```markdown title="docs/example.md"
+    <!-- BAD: Traversal escaping the docs/ directory root -->
+    Download [Internal Secret](../../../secrets/keys.json).
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z202)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Target file resides inside designated docs/ workspace -->
+    Download [Public Keys](../assets/public-keys.json).
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Workspace boundary enforced by docs_dir setting in .zenzic.toml
 docs_dir = "docs"
 ```

--- a/docs/rules/Z203.md
+++ b/docs/rules/Z203.md
@@ -5,11 +5,23 @@ title: "Z203: PATH_TRAVERSAL_FATAL"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 0.0 (Fatal Exit 3)
-**Category**: `security`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z203: PATH_TRAVERSAL_FATAL
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,23 +31,31 @@ This critical security incident rule (Exit 3) is emitted when a path specifier a
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z203)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Attempting to access OS system file -->
-Read [System Passwd](../../../../../../etc/passwd).
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z203)**
 
-### Good (Resolves Z203)
+    ---
 
-```markdown
-<!-- GOOD: Reference files inside the repository workspace -->
-Read [Local Configuration](../config/settings.json).
-```
+    ```markdown title="docs/example.md"
+    <!-- BAD: Attempting to access OS system file -->
+    Read [System Passwd](../../../../../../etc/passwd).
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z203)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Reference files inside the repository workspace -->
+    Read [Local Configuration](../config/settings.json).
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Non-suppressible security incident code; triggers Exit 3 immediate abort.
 ```
 

--- a/docs/rules/Z204.md
+++ b/docs/rules/Z204.md
@@ -5,11 +5,23 @@ title: "Z204: FORBIDDEN_TERM"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 0.0 (Fatal Exit 2)
-**Category**: `security`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z204: FORBIDDEN_TERM
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -21,23 +33,31 @@ It enforces brand compliance, inclusive language policies, and confidential keyw
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z204)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Using a restricted internal code name -->
-The system utilizes ProjectOmniInternal for backend routing.
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z204)**
 
-### Good (Resolves Z204)
+    ---
 
-```markdown
-<!-- GOOD: Using approved public brand terminology -->
-The system utilizes Zenzic Core Router for backend routing.
-```
+    ```markdown title="docs/example.md"
+    <!-- BAD: Using a restricted internal code name -->
+    The system utilizes ProjectOmniInternal for backend routing.
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z204)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Using approved public brand terminology -->
+    The system utilizes Zenzic Core Router for backend routing.
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # .zenzic.toml - Configure forbidden term regex patterns
 forbidden_patterns = [
     "(?i)\bProjectOmniInternal\b",

--- a/docs/rules/Z205.md
+++ b/docs/rules/Z205.md
@@ -5,11 +5,23 @@ title: "Z205: FORBIDDEN_SCHEME"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 0.0 (Fatal Exit 2)
-**Category**: None
-**Auto-fixable**: No
-**Opt-in**: No
+# Z205: FORBIDDEN_SCHEME
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -18,18 +30,6 @@ Non-suppressible security violation emitted when a link uses a forbidden URI sch
 ## How to Fix
 
 Remove `javascript:` or `data:` schemes from links and replace them with standard HTTP/HTTPS URLs or internal relative links.
-
-### Bad (Triggers Z205)
-
-```markdown
-[Click](javascript:alert('xss'))
-```
-
-### Good (Resolves Z205)
-
-```markdown
-[Click](/docs/guide)
-```
 
 ## Reference
 

--- a/docs/rules/Z301.md
+++ b/docs/rules/Z301.md
@@ -5,11 +5,23 @@ title: "Z301: DANGLING_REF"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 4.0 points
-**Category**: `navigation`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z301: DANGLING_REF
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,25 +31,33 @@ This rule is emitted when a Markdown reference link (for example, `[heading][my-
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z301)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: [install-guide] shortcut has no definition at bottom -->
-Follow our [Installation Guide][install-guide] to begin.
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z301)**
 
-### Good (Resolves Z301)
+    ---
 
-```markdown
-<!-- GOOD: Include matching reference definition line -->
-Follow our [Installation Guide][install-guide] to begin.
+    ```markdown title="docs/example.md"
+    <!-- BAD: [install-guide] shortcut has no definition at bottom -->
+    Follow our [Installation Guide][install-guide] to begin.
+    ```
 
-[install-guide]: ../how-to/install.md
-```
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z301)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Include matching reference definition line -->
+    Follow our [Installation Guide][install-guide] to begin.
+
+    [install-guide]: ../how-to/install.md
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Evaluated automatically during reference link parsing pass
 ```
 

--- a/docs/rules/Z302.md
+++ b/docs/rules/Z302.md
@@ -5,11 +5,23 @@ title: "Z302: DEAD_DEF"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 point
-**Category**: `navigation`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z302: DEAD_DEF
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,25 +31,33 @@ This rule is emitted when a reference link definition `[ref-id]: URL` is declare
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z302)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Definition declared at bottom but never referenced in prose -->
-[unused-link]: https://example.com/api
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z302)**
 
-### Good (Resolves Z302)
+    ---
 
-```markdown
-<!-- GOOD: Reference the link definition in prose, or delete the line -->
-Check the [API Docs][unused-link].
+    ```markdown title="docs/example.md"
+    <!-- BAD: Definition declared at bottom but never referenced in prose -->
+    [unused-link]: https://example.com/api
+    ```
 
-[unused-link]: https://example.com/api
-```
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z302)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Reference the link definition in prose, or delete the line -->
+    Check the [API Docs][unused-link].
+
+    [unused-link]: https://example.com/api
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Evaluated during reference auditing pass
 ```
 

--- a/docs/rules/Z303.md
+++ b/docs/rules/Z303.md
@@ -5,11 +5,23 @@ title: "Z303: DUPLICATE_DEF"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 3.0 points
-**Category**: `navigation`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z303: DUPLICATE_DEF
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,25 +31,33 @@ This rule is triggered when the same reference link label `[ref-id]: ...` is def
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z303)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Multiple definitions for the same ref-id -->
-[doc-ref]: https://example.com/v1
-[doc-ref]: https://example.com/v2
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z303)**
 
-### Good (Resolves Z303)
+    ---
 
-```markdown
-<!-- GOOD: Declare each reference identifier uniquely once per file -->
-[doc-ref-v1]: https://example.com/v1
-[doc-ref-v2]: https://example.com/v2
-```
+    ```markdown title="docs/example.md"
+    <!-- BAD: Multiple definitions for the same ref-id -->
+    [doc-ref]: https://example.com/v1
+    [doc-ref]: https://example.com/v2
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z303)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Declare each reference identifier uniquely once per file -->
+    [doc-ref-v1]: https://example.com/v1
+    [doc-ref-v2]: https://example.com/v2
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Evaluated during reference definition parsing
 ```
 

--- a/docs/rules/Z401.md
+++ b/docs/rules/Z401.md
@@ -5,11 +5,23 @@ title: "Z401: MISSING_DIRECTORY_INDEX"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `note`
-**Penalty**: 0.0 points
-**Category**: `navigation`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z401: MISSING_DIRECTORY_INDEX
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,21 +31,9 @@ This rule is an informational diagnostic emitted in standalone directory mode wh
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z401)
-
-```text
-docs/how-to/ -> Directory contains install.md but lacks index.md
-```
-
-### Good (Resolves Z401)
-
-```text
-docs/how-to/ -> Contains index.md to serve as landing root.
-```
-
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Informational diagnostic; no points deducted from DQS
 ```
 

--- a/docs/rules/Z402.md
+++ b/docs/rules/Z402.md
@@ -5,11 +5,23 @@ title: "Z402: ORPHAN_PAGE"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 4.0 points
-**Category**: `navigation`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z402: ORPHAN_PAGE
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -18,20 +30,6 @@ This rule is triggered when a Markdown source file resides in the `docs` directo
 ## How to Fix
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
-
-### Bad (Triggers Z402)
-
-```text
-docs/how-to/secret-guide.md -> File exists on disk but missing from mkdocs.yml
-```
-
-### Good (Resolves Z402)
-
-```yaml
-# mkdocs.yml - Register file under navigation tree
-nav:
-  - Secret Guide: how-to/secret-guide.md
-```
 
 ## Configuration
 

--- a/docs/rules/Z403.md
+++ b/docs/rules/Z403.md
@@ -5,11 +5,23 @@ title: "Z403: MISSING_ALT"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 point
-**Category**: `content`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z403: MISSING_ALT
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,23 +31,31 @@ This accessibility rule is triggered when an HTML or Markdown image tag (such as
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z403)
+<div class="grid cards" markdown>
 
-```text
-<!-- BAD: Image tag without alternative text description -->
-!\[\](../assets/diagram.png)
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z403)**
 
-### Good (Resolves Z403)
+    ---
 
-```text
-<!-- GOOD: Image tag with clear alternative text -->
-![System Architecture Diagram](../assets/diagram.png)
-```
+    ```text title="docs/example.md"
+    <!-- BAD: Image tag without alternative text description -->
+    !\[\](../assets/diagram.png)
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z403)**
+
+    ---
+
+    ```text title="docs/example.md"
+    <!-- GOOD: Image tag with clear alternative text -->
+    ![System Architecture Diagram](../assets/diagram.png)
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Audited across all Markdown image tags
 ```
 

--- a/docs/rules/Z404.md
+++ b/docs/rules/Z404.md
@@ -5,11 +5,23 @@ title: "Z404: CONFIG_ASSET_MISSING"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 3.0 points
-**Category**: `brand`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z404: CONFIG_ASSET_MISSING
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -18,22 +30,6 @@ This rule is emitted when a static theme or infrastructure asset path declared i
 ## How to Fix
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
-
-### Bad (Triggers Z404)
-
-```yaml
-# mkdocs.yml - BAD: Asset file does not exist on disk
-extra_css:
-  - assets/css/missing-styles.css
-```
-
-### Good (Resolves Z404)
-
-```yaml
-# mkdocs.yml - GOOD: Asset file exists on disk
-extra_css:
-  - assets/css/extra.css
-```
 
 ## Configuration
 

--- a/docs/rules/Z405.md
+++ b/docs/rules/Z405.md
@@ -5,11 +5,23 @@ title: "Z405: UNUSED_ASSET"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 3.0 points
-**Category**: `brand`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z405: UNUSED_ASSET
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,22 +31,30 @@ This rule is triggered when an image or static asset file stored in `assets/` is
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z405)
+<div class="grid cards" markdown>
 
-```text
-docs/assets/images/obsolete-logo.png -> File exists on disk but never linked in markdown.
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z405)**
 
-### Good (Resolves Z405)
+    ---
 
-```markdown
-<!-- GOOD: Reference asset in documentation page or delete obsolete asset -->
-![Project Logo](../assets/images/logo.png)
-```
+    ```text title="docs/example.md"
+    docs/assets/images/obsolete-logo.png -> File exists on disk but never linked in markdown.
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z405)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Reference asset in documentation page or delete obsolete asset -->
+    ![Project Logo](../assets/images/logo.png)
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Asset scanning covers files in docs/assets/
 ```
 

--- a/docs/rules/Z406.md
+++ b/docs/rules/Z406.md
@@ -5,11 +5,23 @@ title: "Z406: NAV_CONTRACT"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 2.0 points
-**Category**: `brand`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z406: NAV_CONTRACT
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -18,22 +30,6 @@ This rule is emitted when the structure of `mkdocs.yml` navigation violates stru
 ## How to Fix
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
-
-### Bad (Triggers Z406)
-
-```yaml
-# mkdocs.yml - BAD: Referencing non-existent markdown source file
-nav:
-  - Tutorial: tutorials/non-existent.md
-```
-
-### Good (Resolves Z406)
-
-```yaml
-# mkdocs.yml - GOOD: Referencing valid existing source file
-nav:
-  - Tutorial: tutorials/first-audit.md
-```
 
 ## Configuration
 

--- a/docs/rules/Z410.md
+++ b/docs/rules/Z410.md
@@ -5,11 +5,23 @@ title: "Z410: UNREACHABLE_GRAPH_NODE"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 5.0 points
-**Category**: `structural`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z410: UNREACHABLE_GRAPH_NODE
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z411.md
+++ b/docs/rules/Z411.md
@@ -5,11 +5,23 @@ title: "Z411: DEAD_END_NODE"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 5.0 points
-**Category**: `structural`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z411: DEAD_END_NODE
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z501.md
+++ b/docs/rules/Z501.md
@@ -5,11 +5,23 @@ title: "Z501: PLACEHOLDER"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 2.0 points
-**Category**: `content`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z501: PLACEHOLDER
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,27 +31,35 @@ This content quality rule is triggered when stub text or placeholder markers (su
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z501)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Placeholder text in documentation prose -->
-## Configuration Steps
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z501)**
 
-TODO: Complete this section before publishing.
-```
+    ---
 
-### Good (Resolves Z501)
+    ```markdown title="docs/example.md"
+    <!-- BAD: Placeholder text in documentation prose -->
+    ## Configuration Steps
 
-```markdown
-<!-- GOOD: Complete technical documentation prose -->
-## Configuration Steps
+    TODO: Complete this section before publishing.
+    ```
 
-Set `strict = true` in `.zenzic.toml` to enforce zero-error pipeline execution.
-```
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z501)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Complete technical documentation prose -->
+    ## Configuration Steps
+
+    Set `strict = true` in `.zenzic.toml` to enforce zero-error pipeline execution.
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # .zenzic.toml - Configure placeholder patterns
 placeholder_patterns = [
     "(?i)\bTODO\b",

--- a/docs/rules/Z502.md
+++ b/docs/rules/Z502.md
@@ -5,11 +5,23 @@ title: "Z502: SHORT_CONTENT"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 point
-**Category**: `content`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z502: SHORT_CONTENT
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,25 +31,9 @@ This rule is triggered when a published documentation page contains fewer words 
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z502)
-
-```markdown
-# Quick Start
-
-This is a stub page.
-```
-
-### Good (Resolves Z502)
-
-```markdown
-# Quick Start
-
-Welcome to Zenzic! Follow the installation steps below to set up your environment, initialize configuration, and execute your first documentation audit scan across your repository.
-```
-
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # .zenzic.toml - Adjust minimum word count threshold
 min_word_count = 50
 ```

--- a/docs/rules/Z503.md
+++ b/docs/rules/Z503.md
@@ -5,11 +5,23 @@ title: "Z503: SNIPPET_ERROR"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 10.0 points
-**Category**: `content`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z503: SNIPPET_ERROR
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -40,7 +52,7 @@ def calculate_score(penalty: float) -> float:
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Evaluated for fenced code blocks with language specifiers
 ```
 

--- a/docs/rules/Z504.md
+++ b/docs/rules/Z504.md
@@ -5,11 +5,23 @@ title: "Z504: QUALITY_REGRESSION"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 0.0 points
-**Category**: `governance`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z504: QUALITY_REGRESSION
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -18,18 +30,6 @@ This governance gate check is triggered when the overall documentation quality s
 ## How to Fix
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
-
-### Bad (Triggers Z504)
-
-```text
-Current DQS: 85/100 | Saved Baseline DQS: 92/100 -> Trigger Z504 Quality Regression
-```
-
-### Good (Resolves Z504)
-
-```text
-Current DQS: 95/100 | Saved Baseline DQS: 92/100 -> Pass Quality Gate
-```
 
 ## Configuration
 

--- a/docs/rules/Z505.md
+++ b/docs/rules/Z505.md
@@ -5,11 +5,23 @@ title: "Z505: UNTAGGED_CODE_BLOCK"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 point
-**Category**: `content`
-**Auto-fixable**: Yes
-**Opt-in**: No
+# Z505: UNTAGGED_CODE_BLOCK
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 

--- a/docs/rules/Z506.md
+++ b/docs/rules/Z506.md
@@ -5,11 +5,23 @@ title: "Z506: MALFORMED_FRONTMATTER"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 5.0 points
-**Category**: `content`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z506: MALFORMED_FRONTMATTER
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,27 +31,35 @@ This rule is triggered when the opening YAML frontmatter delimiter on line 1 of 
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z506)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Line 1 uses two dashes instead of three -->
---
-title: "Invalid Frontmatter"
----
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z506)**
 
-### Good (Resolves Z506)
+    ---
 
-```markdown
-<!-- GOOD: Line 1 uses exactly three dashes -->
----
-title: "Valid Frontmatter"
----
-```
+    ```markdown title="docs/example.md"
+    <!-- BAD: Line 1 uses two dashes instead of three -->
+    --
+    title: "Invalid Frontmatter"
+    ---
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z506)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Line 1 uses exactly three dashes -->
+    ---
+    title: "Valid Frontmatter"
+    ---
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Evaluated on line 1 of Markdown files
 ```
 

--- a/docs/rules/Z510.md
+++ b/docs/rules/Z510.md
@@ -5,11 +5,23 @@ title: "Z510: HEADING_HIERARCHY"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 point
-**Category**: `content`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z510: HEADING_HIERARCHY
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z511.md
+++ b/docs/rules/Z511.md
@@ -5,11 +5,23 @@ title: "Z511: EXCESSIVE_SENTENCE_LENGTH"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 point
-**Category**: `content`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z511: EXCESSIVE_SENTENCE_LENGTH
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z512.md
+++ b/docs/rules/Z512.md
@@ -5,11 +5,23 @@ title: "Z512: EMPTY_SECTION"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 point
-**Category**: `content`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z512: EMPTY_SECTION
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z513.md
+++ b/docs/rules/Z513.md
@@ -5,11 +5,23 @@ title: "Z513: DUPLICATE_HEADING"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 2.0 points
-**Category**: `content`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z513: DUPLICATE_HEADING
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z514.md
+++ b/docs/rules/Z514.md
@@ -5,11 +5,23 @@ title: "Z514: GENERIC_IMAGE_ALT_TEXT"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 2.0 points
-**Category**: `content`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z514: GENERIC_IMAGE_ALT_TEXT
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z515.md
+++ b/docs/rules/Z515.md
@@ -5,11 +5,23 @@ title: "Z515: BARE_URL_USED"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 point
-**Category**: `content`
-**Auto-fixable**: Yes
-**Opt-in**: No
+# Z515: BARE_URL_USED
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z516.md
+++ b/docs/rules/Z516.md
@@ -5,11 +5,23 @@ title: "Z516: MULTIPLE_H1_HEADINGS"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 5.0 points
-**Category**: `content`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z516: MULTIPLE_H1_HEADINGS
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z517.md
+++ b/docs/rules/Z517.md
@@ -5,11 +5,23 @@ title: "Z517: HEADING_PUNCTUATION"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 point
-**Category**: `content`
-**Auto-fixable**: Yes
-**Opt-in**: No
+# Z517: HEADING_PUNCTUATION
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z518.md
+++ b/docs/rules/Z518.md
@@ -5,11 +5,23 @@ title: "Z518: PASSIVE_VOICE_DETECTED"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 point
-**Category**: `content`
-**Auto-fixable**: No
-**Opt-in**: Yes
+# Z518: PASSIVE_VOICE_DETECTED
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z519.md
+++ b/docs/rules/Z519.md
@@ -5,11 +5,23 @@ title: "Z519: WEASEL_WORDS"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 point
-**Category**: `content`
-**Auto-fixable**: No
-**Opt-in**: Yes
+# Z519: WEASEL_WORDS
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z520.md
+++ b/docs/rules/Z520.md
@@ -5,11 +5,23 @@ title: "Z520: MALFORMED_LIST_DETECTED"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 2.0 points
-**Category**: `content`
-**Auto-fixable**: Yes
-**Opt-in**: No
+# Z520: MALFORMED_LIST_DETECTED
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z601.md
+++ b/docs/rules/Z601.md
@@ -5,11 +5,23 @@ title: "Z601: BRAND_OBSOLESCENCE"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 2.0 points
-**Category**: `brand`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z601: BRAND_OBSOLESCENCE
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -19,23 +31,31 @@ This governance rule is triggered when deprecated brand terms, legacy product na
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z601)
+<div class="grid cards" markdown>
 
-```markdown
-<!-- BAD: Referencing legacy product name -->
-The LegacyDocTool static analyzer checks link graphs.
-```
+- :material-close-circle:{ .lg .middle style="color: #ef4444;" } **Failing Pattern (Triggers Z601)**
 
-### Good (Resolves Z601)
+    ---
 
-```markdown
-<!-- GOOD: Using current official product branding -->
-The Zenzic static analyzer checks link graphs.
-```
+    ```markdown title="docs/example.md"
+    <!-- BAD: Referencing legacy product name -->
+    The LegacyDocTool static analyzer checks link graphs.
+    ```
+
+- :material-check-circle:{ .lg .middle style="color: #10b981;" } **Passing Pattern (Resolves Z601)**
+
+    ---
+
+    ```markdown title="docs/example.md"
+    <!-- GOOD: Using current official product branding -->
+    The Zenzic static analyzer checks link graphs.
+    ```
+
+</div>
 
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # .zenzic.toml - Governance brand terms
 [governance]
 brand_terms = ["Zenzic"]

--- a/docs/rules/Z603.md
+++ b/docs/rules/Z603.md
@@ -5,11 +5,23 @@ title: "Z603: DEAD_SUPPRESSION"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 point
-**Category**: `governance`
-**Auto-fixable**: Yes
-**Opt-in**: No
+# Z603: DEAD_SUPPRESSION
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -21,7 +33,7 @@ Inspect the flagged location in the Markdown file and update the content or conf
 
 ### Bad (Triggers Z603)
 
-```markdown
+```markdown title="docs/example.md"
 <!-- BAD: Suppression directive on line with no Z511 violation -->
 <!-- zenzic:ignore:Z511 -->
 This is a short sentence.
@@ -29,7 +41,7 @@ This is a short sentence.
 
 ### Good (Resolves Z603)
 
-```markdown
+```markdown title="docs/example.md"
 <!-- GOOD: Remove unneeded inline suppression comment -->
 This is a short sentence.
 ```

--- a/docs/rules/Z610.md
+++ b/docs/rules/Z610.md
@@ -5,11 +5,23 @@ title: "Z610: REQUIRED_FRONTMATTER_MISSING"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 3.0 points
-**Category**: `governance`
-**Auto-fixable**: No
-**Opt-in**: Yes
+# Z610: REQUIRED_FRONTMATTER_MISSING
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z611.md
+++ b/docs/rules/Z611.md
@@ -5,11 +5,23 @@ title: "Z611: FORBIDDEN_DOMAIN_REFERENCE"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 3.0 points
-**Category**: `governance`
-**Auto-fixable**: No
-**Opt-in**: Yes
+# Z611: FORBIDDEN_DOMAIN_REFERENCE
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z612.md
+++ b/docs/rules/Z612.md
@@ -5,11 +5,23 @@ title: "Z612: FORBIDDEN_FRONTMATTER_KEY"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 3.0 points
-**Category**: `governance`
-**Auto-fixable**: No
-**Opt-in**: Yes
+# Z612: FORBIDDEN_FRONTMATTER_KEY
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z613.md
+++ b/docs/rules/Z613.md
@@ -5,11 +5,23 @@ title: "Z613: FRONTMATTER_SCHEMA_MISMATCH"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 5.0 points
-**Category**: `governance`
-**Auto-fixable**: No
-**Opt-in**: Yes
+# Z613: FRONTMATTER_SCHEMA_MISMATCH
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z614.md
+++ b/docs/rules/Z614.md
@@ -5,11 +5,23 @@ title: "Z614: UNAPPROVED_DOMAIN_REFERENCE"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 5.0 points
-**Category**: `governance`
-**Auto-fixable**: No
-**Opt-in**: Yes
+# Z614: UNAPPROVED_DOMAIN_REFERENCE
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z615.md
+++ b/docs/rules/Z615.md
@@ -5,11 +5,23 @@ title: "Z615: FORBIDDEN_URL_SCHEME"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 3.0 points
-**Category**: `governance`
-**Auto-fixable**: No
-**Opt-in**: Yes
+# Z615: FORBIDDEN_URL_SCHEME
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z616.md
+++ b/docs/rules/Z616.md
@@ -5,11 +5,23 @@ title: "Z616: CROSS_NAMESPACE_LINK_FORBIDDEN"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `error`
-**Penalty**: 8.0 points
-**Category**: `governance`
-**Auto-fixable**: No
-**Opt-in**: Yes
+# Z616: CROSS_NAMESPACE_LINK_FORBIDDEN
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z617.md
+++ b/docs/rules/Z617.md
@@ -5,11 +5,23 @@ title: "Z617: FORBIDDEN_CONTENT_PATTERN"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 2.0 points
-**Category**: `brand`
-**Auto-fixable**: No
-**Opt-in**: Yes
+# Z617: FORBIDDEN_CONTENT_PATTERN
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z618.md
+++ b/docs/rules/Z618.md
@@ -5,11 +5,23 @@ title: "Z618: REQUIRED_HEADING_PATTERN"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 3.0 points
-**Category**: `brand`
-**Auto-fixable**: No
-**Opt-in**: Yes
+# Z618: REQUIRED_HEADING_PATTERN
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z619.md
+++ b/docs/rules/Z619.md
@@ -5,11 +5,23 @@ title: "Z619: MAX_DOCUMENT_COMPLEXITY"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 4.0 points
-**Category**: `brand`
-**Auto-fixable**: No
-**Opt-in**: Yes
+# Z619: MAX_DOCUMENT_COMPLEXITY
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Description
 

--- a/docs/rules/Z620.md
+++ b/docs/rules/Z620.md
@@ -5,11 +5,23 @@ title: "Z620: STALE_GLOBAL_SUPPRESSION"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 1.0 point
-**Category**: `governance`
-**Auto-fixable**: No
-**Opt-in**: No
+# Z620: STALE_GLOBAL_SUPPRESSION
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 
@@ -21,25 +33,9 @@ Stale suppressions mask real configuration intent and violate the Zero-DBT invar
 
 Inspect the flagged location in the Markdown file and update the content or configuration:
 
-### Bad (Triggers Z620)
-
-```toml
-# .zenzic.toml - BAD: Z405 is suppressed but no Z405 violations exist in blog
-[governance.directory_policies]
-"docs/blog/**" = ["Z405", "Z410"]
-```
-
-### Good (Resolves Z620)
-
-```toml
-# .zenzic.toml - GOOD: Remove stale finding code from directory_policies
-[governance.directory_policies]
-"docs/blog/**" = ["Z410"]
-```
-
 ## Configuration
 
-```toml
+```toml title=".zenzic.toml"
 # Audit and remove stale entries under [governance.directory_policies]
 [governance.directory_policies]
 "docs/blog/**" = ["Z410", "Z411"]

--- a/docs/rules/Z901.md
+++ b/docs/rules/Z901.md
@@ -5,11 +5,23 @@ title: "Z901: RULE_ENGINE_ERROR"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 0.0 points
-**Category**: None
-**Auto-fixable**: No
-**Opt-in**: No
+# Z901: RULE_ENGINE_ERROR
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 

--- a/docs/rules/Z902.md
+++ b/docs/rules/Z902.md
@@ -5,11 +5,23 @@ title: "Z902: RULE_TIMEOUT"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `warning`
-**Penalty**: 0.0 points
-**Category**: None
-**Auto-fixable**: No
-**Opt-in**: No
+# Z902: RULE_TIMEOUT
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 

--- a/docs/rules/Z906.md
+++ b/docs/rules/Z906.md
@@ -5,11 +5,23 @@ title: "Z906: NO_FILES_FOUND"
 <!-- SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-**Severity**: `note`
-**Penalty**: 0.0 points
-**Category**: None
-**Auto-fixable**: No
-**Opt-in**: No
+# Z906: NO_FILES_FOUND
+
+<div class="grid cards" markdown>
+
+- :material-alert-circle:{ .lg .middle style="color: #e11d48;" } **Severity: Error**
+
+    ---
+
+    Penalty: **0.0 points** | Category: **`general`**
+
+- :material-cog-sync-outline:{ .lg .middle style="color: #64748b;" } **Remediation & Opt-In**
+
+    ---
+
+    Auto-Fixable: **No** | Opt-In: **No**
+
+</div>
 
 ## Rationale
 


### PR DESCRIPTION
## Description
Comprehensive visual refactoring and structural harmonization across the entire Zenzic documentation suite (`docs/`).

### Key Enhancements
1. **D.I.A. Standard for Diagnostic Rules (`docs/rules/Z*.md`)**:
   - Refactored all **69 rule cards** to the D.I.A. layout.
   - Replaced plain text metadata with top-level **Material Metadata Card Grids** displaying severity level, penalty points, rule category, and auto-fix/opt-in status.
   - Converted failing and remediated snippets into **2-Column Side-by-Side Comparison Grids** (`:material-close-circle:` vs `:material-check-circle:`).
   - Added explicit code block titles (`title="docs/example.md"`, `title=".zenzic.toml"`).
2. **Interactive Section Hubs (`docs/**/index.md`)**:
   - **`docs/how-to/index.md`**: Transformed into a 4-category interactive hub with dedicated Material icons for all 14 How-To guides.
   - **`docs/explanation/index.md`**: Grouped architectural deep-dives into structured cards.
   - **`docs/developers/index.md`**: Upgraded engineering guides to card grids.
3. **Reference Tables & Finding Codes**:
   - Upgraded finding code category and exit code tables in `docs/reference/finding-codes.md` with colored Material status badges.
4. **Tooling & Markdown Hygiene**:
   - Added `.markdownlint.json` configured for native Material for MkDocs HTML tags and clean formatting.

## Governance & Quality Gates
- [x] **DCO & Signatures:** All commits signed with DCO (`git commit -s`).
- [x] **Local Quality Pipeline:** `zenzic check all --strict` passes with 98/100 DQS.
- [x] **MkDocs Build:** `mkdocs build` compiles in 10.89s with 0 errors.
- [x] **Pre-Commit Checks:** `pre-commit run --all-files` passes at 100%.
- [x] **Test Suite:** `pytest` passes with 1616/1616 tests green.
