### PR TITLE
fix(docs): enable MathJax client-side scripts for LaTeX mathematical formula rendering

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,19 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex"
+  }
+};
+
+document$.subscribe(() => {
+  MathJax.startup.output.clearCache();
+  MathJax.typesetClear();
+  MathJax.texReset();
+  MathJax.typesetPromise();
+});

--- a/docs/javascripts/mathjax.js.license
+++ b/docs/javascripts/mathjax.js.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev>
+SPDX-License-Identifier: Apache-2.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,11 @@ extra_css:
   # Preflight (CSS Reset) is DISABLED to prevent interference with Material base typography.
   # See docs/assets/css/README.md for the build protocol.
 
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+
+
 exclude_docs: |
   assets/css/README.md
 


### PR DESCRIPTION
## Description
Enables client-side MathJax 3 rendering scripts for LaTeX equations across all documentation pages.

### Cause of Previous Text Fallback
- `pymdownx.arithmatex: generic: true` generates HTML tags with `<span class="arithmatex">\(...\)</span>` and `<div class="arithmatex">\[...\]</div>`.
- In Material for MkDocs, `generic: true` requires loading the MathJax client-side JavaScript engine in `extra_javascript:` to parse and typeset the equations into mathematical symbols and fractions. Without this script, the raw LaTeX code was rendered as unstyled plain text.

### Key Changes
1. Created `docs/javascripts/mathjax.js` configured for MathJax 3 with support for instant navigation (`document$.subscribe`).
2. Added `extra_javascript` in `mkdocs.yml` loading `javascripts/mathjax.js` and the MathJax CDN engine.
3. Verified complete rendering across `docs/reference/scoring-algorithm.md`, `docs/explanation/scoring-system.md`, `docs/explanation/core-mechanics.md`, and all mathematical blog posts.

## Governance & Quality Checklist
- [x] **DCO & Signatures:** All commits signed with DCO (`git commit -s`).
- [x] **Local Quality Pipeline:** `pre-commit run --all-files` and `mkdocs build` pass with 100% success.
