### PR TITLE
fix(rss): fix HTML-in-clear in feed descriptions and upgrade feed quality

### DIFF
--- a/docs/blog/atom.xsl
+++ b/docs/blog/atom.xsl
@@ -3,9 +3,9 @@
 SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev>
 SPDX-License-Identifier: Apache-2.0
 
-RSS 2.0 Browser Stylesheet for Zenzic Blog
-Renders a human-readable HTML page when the feed is opened in a browser.
-Feed readers receive the raw XML and ignore this stylesheet entirely.
+Atom 1.0 Browser Stylesheet for Zenzic Blog
+Renders a human-readable HTML page when the Atom feed is opened in a browser.
+Feed readers receive the raw XML and ignore this stylesheet.
 -->
 <xsl:stylesheet version="1.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -19,7 +19,7 @@ Feed readers receive the raw XML and ignore this stylesheet entirely.
       <head>
         <meta charset="UTF-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-        <title><xsl:value-of select="/rss/channel/title"/> — RSS Feed</title>
+        <title><xsl:value-of select="/atom:feed/atom:title"/> — Atom Feed</title>
         <link rel="stylesheet" href="/assets/css/zenzic-tailwind.min.css"/>
         <link rel="stylesheet" href="/assets/css/extra.css"/>
         <style>
@@ -61,8 +61,8 @@ Feed readers receive the raw XML and ignore this stylesheet entirely.
             align-items: center;
             gap: 0.5rem;
             padding: 0.5rem 1.1rem;
-            background: var(--zz-rss-accent);
-            color: #fff;
+            background: #f59e0b;
+            color: #000;
             font-size: 0.82rem;
             font-weight: 600;
             border-radius: 20px;
@@ -81,12 +81,7 @@ Feed readers receive the raw XML and ignore this stylesheet entirely.
             color: var(--zz-rss-muted);
           }
           .rss-notice strong { color: var(--zz-rss-text); }
-          .rss-notice code {
-            background: #0d1117;
-            padding: 0.1em 0.35em;
-            border-radius: 3px;
-            font-size: 0.85em;
-          }
+          .rss-notice code { background: #0d1117; padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.85em; }
           .rss-notice a { color: var(--zz-rss-link); }
           .rss-meta { margin-bottom: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--zz-rss-border); }
           .rss-meta dl { display: grid; grid-template-columns: max-content 1fr; column-gap: 1.25rem; row-gap: 0.3rem; margin: 0; }
@@ -98,25 +93,9 @@ Feed readers receive the raw XML and ignore this stylesheet entirely.
           .rss-item-title { margin: 0 0 0.4rem; font-size: 1.05rem; font-weight: 700; }
           .rss-item-title a { color: #fff; text-decoration: none; }
           .rss-item-title a:hover { color: var(--zz-rss-accent); }
-          .rss-item-meta {
-            display: flex;
-            flex-wrap: wrap;
-            align-items: center;
-            gap: 0.45rem;
-            margin-bottom: 0.75rem;
-            font-size: 0.78rem;
-            color: var(--zz-rss-muted);
-          }
+          .rss-item-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 0.45rem; margin-bottom: 0.75rem; font-size: 0.78rem; color: var(--zz-rss-muted); }
           .sep { opacity: 0.4; }
-          .rss-category {
-            display: inline-block;
-            padding: 0.1rem 0.55rem;
-            background: var(--zz-rss-badge-bg);
-            border: 1px solid var(--zz-rss-border);
-            border-radius: 20px;
-            font-size: 0.72rem;
-            color: var(--zz-rss-muted);
-          }
+          .rss-category { display: inline-block; padding: 0.1rem 0.55rem; background: var(--zz-rss-badge-bg); border: 1px solid var(--zz-rss-border); border-radius: 20px; font-size: 0.72rem; color: var(--zz-rss-muted); }
           .rss-item-description { font-size: 0.88rem; color: var(--zz-rss-text); line-height: 1.65; margin: 0 0 0.85rem; }
           .rss-item-description p { margin: 0 0 0.5em; }
           .rss-item-description code { background: var(--zz-rss-badge-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.82em; }
@@ -132,56 +111,61 @@ Feed readers receive the raw XML and ignore this stylesheet entirely.
         <header class="rss-header">
           <img class="rss-logo" src="/assets/brand/svg/zenzic-icon.svg" alt="Zenzic logo"/>
           <div class="rss-header-text">
-            <h1><xsl:value-of select="/rss/channel/title"/></h1>
-            <p><xsl:value-of select="/rss/channel/description"/></p>
+            <h1><xsl:value-of select="/atom:feed/atom:title"/></h1>
+            <p><xsl:value-of select="/atom:feed/atom:subtitle"/></p>
           </div>
-          <a class="rss-subscribe-btn" href="/blog/rss.xml">&#128231; Subscribe via RSS</a>
+          <a class="rss-subscribe-btn" href="/blog/atom.xml">&#9883; Subscribe via Atom</a>
         </header>
         <main class="rss-container">
           <div class="rss-notice">
-            <strong>This is a live RSS feed.</strong>
-            Copy <code><xsl:value-of select="/rss/channel/link"/>blog/rss.xml</code> into your feed reader to stay updated.
-            An <a href="/blog/atom.xml">Atom feed</a> is also available.
+            <strong>This is a live Atom feed (RFC 4287).</strong>
+            Copy <code><xsl:value-of select="/atom:feed/atom:link[@rel='self']/@href"/></code> into your feed reader.
+            An <a href="/blog/rss.xml">RSS 2.0 feed</a> is also available.
           </div>
           <section class="rss-meta">
             <dl>
               <dt>Site</dt>
-              <dd><a href="{/rss/channel/link}"><xsl:value-of select="/rss/channel/link"/></a></dd>
-              <dt>Language</dt>
-              <dd><xsl:value-of select="/rss/channel/language"/></dd>
-              <dt>Last built</dt>
-              <dd><xsl:value-of select="/rss/channel/lastBuildDate"/></dd>
+              <dd>
+                <a>
+                  <xsl:attribute name="href">
+                    <xsl:value-of select="/atom:feed/atom:link[@rel='alternate']/@href"/>
+                  </xsl:attribute>
+                  <xsl:value-of select="/atom:feed/atom:link[@rel='alternate']/@href"/>
+                </a>
+              </dd>
+              <dt>Updated</dt>
+              <dd><xsl:value-of select="/atom:feed/atom:updated"/></dd>
               <dt>Posts</dt>
-              <dd><xsl:value-of select="count(/rss/channel/item)"/></dd>
+              <dd><xsl:value-of select="count(/atom:feed/atom:entry)"/></dd>
             </dl>
           </section>
-          <xsl:for-each select="/rss/channel/item">
+          <xsl:for-each select="/atom:feed/atom:entry">
             <article class="rss-item">
               <h2 class="rss-item-title">
-                <a href="{link}"><xsl:value-of select="title"/></a>
+                <a href="{atom:link/@href}"><xsl:value-of select="atom:title"/></a>
               </h2>
               <div class="rss-item-meta">
-                <span><xsl:value-of select="pubDate"/></span>
-                <xsl:if test="author">
+                <span><xsl:value-of select="atom:published"/></span>
+                <xsl:if test="atom:author/atom:name">
                   <span class="sep">&#183;</span>
-                  <span><xsl:value-of select="author"/></span>
+                  <span><xsl:value-of select="atom:author/atom:name"/></span>
                 </xsl:if>
-                <xsl:if test="category">
+                <xsl:if test="atom:category">
                   <span class="sep">&#183;</span>
-                  <xsl:for-each select="category">
-                    <span class="rss-category"><xsl:value-of select="."/></span>
+                  <xsl:for-each select="atom:category">
+                    <span class="rss-category"><xsl:value-of select="@term"/></span>
                   </xsl:for-each>
                 </xsl:if>
               </div>
               <div class="rss-item-description">
-                <xsl:value-of select="description" disable-output-escaping="yes"/>
+                <xsl:value-of select="atom:summary" disable-output-escaping="yes"/>
               </div>
-              <a class="rss-read-more" href="{link}">Read full article</a>
+              <a class="rss-read-more" href="{atom:link/@href}">Read full article</a>
             </article>
           </xsl:for-each>
           <footer class="rss-footer">
             <p>
-              <a href="/"><xsl:value-of select="/rss/channel/title"/></a> &#183;
+              <a href="/"><xsl:value-of select="/atom:feed/atom:title"/></a> &#183;
               Generated with <a href="https://www.mkdocs.org/" rel="noopener">MkDocs</a>,
               <a href="https://squidfunk.github.io/mkdocs-material/" rel="noopener">Material</a> and
               <a href="https://guts.github.io/mkdocs-rss-plugin/" rel="noopener">mkdocs-rss-plugin</a>

--- a/docs/blog/posts/2026-06-28-v0-17-0-closing-the-html-blind-spot.md
+++ b/docs/blog/posts/2026-06-28-v0-17-0-closing-the-html-blind-spot.md
@@ -11,7 +11,7 @@ categories:
 ---
 With the release of Zenzic v0.17.0, Zenzic expands its validation capabilities beyond Markdown syntax. In addition to Markdown links and assets, Zenzic can now analyze raw HTML references embedded in Markdown documents.
 
-A common limitation of Markdown-focused tooling is that raw HTML embedded inside Markdown documents may not be analyzed with the same level of validation as native Markdown constructs. When developers embed `<a>` tags or `<img>` elements directly into their Markdown to achieve specific layouts or functionality, broken links and missing assets can remain undetected.
+A common limitation of Markdown-focused tooling is that raw HTML embedded inside Markdown documents is not analyzed with the same rigor as native Markdown constructs. When developers embed anchor or image elements directly into their Markdown for custom layouts, broken links and missing assets can remain undetected.
 
 With v0.17.0, HTML links and images are analyzed by the same validation pipeline used for Markdown references.
 

--- a/docs/blog/posts/2026-06-29-10-documentation-bugs-caught-by-zenzic.md
+++ b/docs/blog/posts/2026-06-29-10-documentation-bugs-caught-by-zenzic.md
@@ -10,16 +10,16 @@ categories:
   - Documentation
   - Quality Assurance
 ---
-!!! abstract "Architectural Update"
-    *Historical Note:* This post refers to Zenzic as a "linter". As the system evolved, its capabilities expanded far beyond surface-level linting. Zenzic is now officially classified as a **Deterministic Document Integrity Engine for Markdown/MDX graphs**. Read the [latest documentation](https://zenzic.dev/) for current architectural capabilities.
+Documentation isn't just text — it's a critical interface. When users rely on your docs to deploy infrastructure, configure security policies, or integrate APIs, a "simple typo" can lead to hours of lost productivity.
 
-Documentation isn't just text—it's a critical interface. When users rely on your docs to deploy infrastructure, configure security policies, or integrate APIs, a "simple typo" can lead to hours of lost productivity.
-
-In a docs-as-code workflow, documentation is code. And just like code, it has bugs. That's why we built Zenzic: a zero-config Markdown link and structural integrity auditor.
+In a docs-as-code workflow, documentation is code. And just like code, it has bugs. That's why we built Zenzic: a Deterministic Document Integrity Engine for Markdown/MDX graphs.
 
 Here are 10 subtle, frustrating, and downright dangerous documentation bugs that Zenzic catches automatically in your CI/CD pipelines.
 
 <!-- more -->
+
+!!! abstract "Architectural Update"
+    *Historical Note:* This post refers to Zenzic as a "linter". As the system evolved, its capabilities expanded far beyond surface-level linting. Zenzic is now officially classified as a **Deterministic Document Integrity Engine for Markdown/MDX graphs**. Read the [latest documentation](https://zenzic.dev/) for current architectural capabilities.
 
 ![10 Documentation Bugs Caught by Zenzic](../../assets/images/blog/10-documentation-bugs-caught-by-zenzic.webp)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -385,14 +385,18 @@ plugins:
       pagination_per_page: 10
       pagination_url_format: "page/{page}"
   - rss:
-
       match_path: "blog/posts/.*"
       date_from_meta:
         as_creation: date
       use_material_blog: true
       use_material_social_cards: true
       abstract_delimiter: <!-- more -->
+      abstract_chars_count: 500
+      pretty_print: true
       image: https://zenzic.dev/assets/brand/svg/zenzic-icon.svg
+      feed_description: "Engineering insights, release notes and documentation quality guides from the Zenzic team."
+      feed_ttl: 1440
+      stylesheet: /blog/rss.xsl
       feeds_filenames:
         rss_created: blog/rss.xml
         rss_updated: blog/atom.xml


### PR DESCRIPTION
## Root Causes Fixed

### HTML rendering as plain text in RSS descriptions
- **'10 Documentation Bugs'**: `!!! abstract` Material admonition placed **before** `<!-- more -->` was rendered as literal text `!!! abstract "Architectural Update"` by the RSS plugin (no Material extensions available in its Markdown renderer). Fix: moved admonition after the delimiter; clean plain-text abstract precedes it.
- **'Zenzic v0.17.0'**: Backtick code spans wrapping `<a>`/`<img>` before `<!-- more -->` caused double-encoding in the feed description. Fix: replaced with plain-text equivalents.

## Feed Quality Improvements
- `abstract_chars_count: 500` — sensible excerpt length
- `pretty_print: true` — human-readable indented XML
- `feed_description` — proper channel subtitle for feed readers
- `feed_ttl: 1440` — 24h cache hint for aggregators
- `stylesheet: /blog/rss.xsl` — custom XSL renders styled HTML page in browser

### XSL Stylesheets (professional browser view)
- **Rewrote `rss.xsl`**: dark Material theme, channel metadata `<dl>`, per-item author + category badges, Subscribe banner, read-more links, footer
- **Added `atom.xsl`** for the atom.xml feed (amber accent distinguishes from RSS)

## Quality Checklist
- [x] `mkdocs build --strict`: 9.71s, exit 0
- [x] RSS description for both affected posts: clean plain text, no `!!!` artifacts