### PR TITLE
fix(docs): technical SEO redirects, sitemap hygiene, and PageSpeed KaTeX optimization

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,14 +1,78 @@
 // SPDX-FileCopyrightText: 2026 PythonWoods <dev@pythonwoods.dev>
 // SPDX-License-Identifier: Apache-2.0
 
-document$.subscribe(() => {
-  renderMathInElement(document.body, {
-    delimiters: [
-      { left: "$$",  right: "$$",  display: true },
-      { left: "$",   right: "$",   display: false },
-      { left: "\\(", right: "\\)", display: false },
-      { left: "\\[", right: "\\]", display: true }
-    ],
-    throwOnError: false
+let katexLoadingPromise = null;
+
+function renderMath() {
+  if (typeof renderMathInElement === "function") {
+    renderMathInElement(document.body, {
+      delimiters: [
+        { left: "$$",  right: "$$",  display: true },
+        { left: "$",   right: "$",   display: false },
+        { left: "\\(", right: "\\)", display: false },
+        { left: "\\[", right: "\\]", display: true }
+      ],
+      throwOnError: false
+    });
+  }
+}
+
+function loadKaTeX() {
+  if (katexLoadingPromise) {
+    return katexLoadingPromise;
+  }
+
+  katexLoadingPromise = new Promise((resolve, reject) => {
+    // 1. Inject KaTeX CSS with SRI
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css";
+    link.integrity = "sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+";
+    link.crossOrigin = "anonymous";
+    link.onerror = (err) => {
+      console.warn("[Zenzic] Failed to load KaTeX stylesheet:", err);
+    };
+    document.head.appendChild(link);
+
+    // 2. Inject KaTeX Core JS with SRI
+    const script = document.createElement("script");
+    script.src = "https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js";
+    script.integrity = "sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg";
+    script.crossOrigin = "anonymous";
+    script.onerror = (err) => {
+      console.warn("[Zenzic] Failed to load KaTeX core script:", err);
+      reject(err);
+    };
+
+    script.onload = () => {
+      // 3. Inject KaTeX Auto-render Extension with SRI
+      const autoRender = document.createElement("script");
+      autoRender.src = "https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js";
+      autoRender.integrity = "sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk";
+      autoRender.crossOrigin = "anonymous";
+      autoRender.onerror = (err) => {
+        console.warn("[Zenzic] Failed to load KaTeX auto-render extension:", err);
+        reject(err);
+      };
+      autoRender.onload = () => {
+        resolve();
+      };
+      document.head.appendChild(autoRender);
+    };
+
+    document.head.appendChild(script);
   });
+
+  return katexLoadingPromise;
+}
+
+document$.subscribe(() => {
+  if (document.querySelector(".arithmatex")) {
+    loadKaTeX()
+      .then(() => renderMath())
+      .catch((err) => {
+        console.warn("[Zenzic] Math rendering skipped due to KaTeX load error:", err);
+      });
+  }
 });
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,15 +17,12 @@ copyright: "Copyright &copy; 2026 PythonWoods &mdash; Apache-2.0 License"
 extra_css:
   - assets/css/zenzic-tailwind.min.css
   - assets/css/extra.css
-  - https://unpkg.com/katex@0/dist/katex.min.css
   # EXTERNAL BUILD ARTIFACT — compiled by human-run Tailwind CLI (no Node.js in CI).
   # Preflight (CSS Reset) is DISABLED to prevent interference with Material base typography.
   # See docs/assets/css/README.md for the build protocol.
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://unpkg.com/katex@0/dist/katex.min.js
-  - https://unpkg.com/katex@0/dist/contrib/auto-render.min.js
 
 
 exclude_docs: |


### PR DESCRIPTION
## Summary

This PR resolves technical SEO crawl anomalies reported by Google Search Console and optimizes frontend PageSpeed performance by eliminating render-blocking resources.

### Key Changes

1. **KaTeX Dynamic On-Demand Loading & SRI**:
   - Removed global render-blocking KaTeX CSS and JS assets from `mkdocs.yml`.
   - Rewrote `docs/javascripts/mathjax.js` to dynamically load KaTeX and auto-render on demand only on pages containing math formulas (`.arithmatex`).
   - Added Subresource Integrity (`integrity`) hashes and `crossorigin="anonymous"` to all injected CDN resources.
   - Result: 0 bytes of KaTeX CSS/JS and 0ms render-blocking on Homepage.

2. **Technical SEO & Sitemap Hygiene**:
   - Physically deleted obsolete `docs/explanation/scoring-design.md` and removed its reference from `nav` in `mkdocs.yml`.
   - Maintained active 301 redirect in `docs/_redirects` to `/explanation/scoring-system/`.
   - Added `includes/*` to `exclude_docs` in `mkdocs.yml` to prevent technical snippet files from being compiled into orphan standalone HTML pages or injected into `sitemap.xml`.
   - Fixed broken 404 target in `docs/_redirects` for `/blog/obsidian-masterclass/` to point to `/blog/2026/05/24/engineering-deep-dive-v080-architecture/`.

3. **Homepage CLS Fix & Minification**:
   - Added explicit `width="56" height="56"` attributes to `zenzic-icon.svg` in `overrides/partials/homepage/hero.html` (CLS = 0).
   - Minified design tokens in `docs/assets/css/extra.css`.
   - Locked `mkdocs-minify-plugin` in `pyproject.toml` and `uv.lock` for automatic HTML/CSS minification in CI.

4. **CI Matrix Stabilization**:
   - Temporarily restricted CI test matrix in `.github/workflows/ci.yml` to `ubuntu-latest` with Python `3.10` with clear comments.